### PR TITLE
feat: Phase 2 案件管理機能 + Supabase移行

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,14 +1,14 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from sqlalchemy.orm import Session
+from supabase import Client
 from datetime import timedelta
 from app.core.database import get_db
 from app.core.security import verify_password, get_password_hash, create_access_token, decode_access_token
 from app.core.config import settings
-from app.models.user import User
 from app.schemas.auth import UserCreate, UserResponse, Token, LoginRequest
-from typing import Optional
+from typing import Optional, Dict, Any
 from uuid import UUID
+import uuid
 
 router = APIRouter()
 security = HTTPBearer()
@@ -16,8 +16,8 @@ security = HTTPBearer()
 
 def get_current_user(
     credentials: HTTPAuthorizationCredentials = Depends(security),
-    db: Session = Depends(get_db)
-) -> User:
+    db: Client = Depends(get_db)
+) -> Dict[str, Any]:
     """現在のユーザーを取得"""
     token = credentials.credentials
     payload = decode_access_token(token)
@@ -29,7 +29,7 @@ def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    user_id: Optional[UUID] = payload.get("sub")
+    user_id: Optional[str] = payload.get("sub")
     if user_id is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -37,31 +37,33 @@ def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    user = db.query(User).filter(User.id == user_id).first()
-    if user is None:
+    # Supabase Clientでユーザーを取得
+    response = db.table("users").select("*").eq("id", user_id).execute()
+
+    if not response.data or len(response.data) == 0:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="ユーザーが見つかりません",
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    return user
+    return response.data[0]
 
 
 @router.post("/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
-def register_user(user_data: UserCreate, db: Session = Depends(get_db)):
+def register_user(user_data: UserCreate, db: Client = Depends(get_db)):
     """新規ユーザー登録"""
     # メールアドレスの重複チェック
-    existing_user = db.query(User).filter(User.email == user_data.email).first()
-    if existing_user:
+    existing_email = db.table("users").select("id").eq("email", user_data.email).execute()
+    if existing_email.data:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="このメールアドレスは既に登録されています"
         )
 
     # ユーザー名の重複チェック
-    existing_username = db.query(User).filter(User.username == user_data.username).first()
-    if existing_username:
+    existing_username = db.table("users").select("id").eq("username", user_data.username).execute()
+    if existing_username.data:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="このユーザー名は既に使用されています"
@@ -71,33 +73,49 @@ def register_user(user_data: UserCreate, db: Session = Depends(get_db)):
     hashed_password = get_password_hash(user_data.password)
 
     # ユーザー作成
-    new_user = User(
-        email=user_data.email,
-        username=user_data.username,
-        hashed_password=hashed_password
-    )
+    new_user_data = {
+        "id": str(uuid.uuid4()),
+        "email": user_data.email,
+        "username": user_data.username,
+        "hashed_password": hashed_password,
+        "is_active": True,
+        "is_admin": False
+    }
 
-    db.add(new_user)
-    db.commit()
-    db.refresh(new_user)
+    response = db.table("users").insert(new_user_data).execute()
 
-    return new_user
+    if not response.data:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="ユーザー登録に失敗しました"
+        )
+
+    return response.data[0]
 
 
 @router.post("/login", response_model=Token)
-def login(login_data: LoginRequest, db: Session = Depends(get_db)):
+def login(login_data: LoginRequest, db: Client = Depends(get_db)):
     """ログイン"""
     # ユーザーを検索
-    user = db.query(User).filter(User.email == login_data.email).first()
+    response = db.table("users").select("*").eq("email", login_data.email).execute()
 
-    if not user or not verify_password(login_data.password, user.hashed_password):
+    if not response.data or len(response.data) == 0:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="メールアドレスまたはパスワードが正しくありません",
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    if not user.is_active:
+    user = response.data[0]
+
+    if not verify_password(login_data.password, user["hashed_password"]):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="メールアドレスまたはパスワードが正しくありません",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    if not user.get("is_active", True):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="このアカウントは無効化されています"
@@ -106,7 +124,7 @@ def login(login_data: LoginRequest, db: Session = Depends(get_db)):
     # アクセストークンを生成
     access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     access_token = create_access_token(
-        data={"sub": str(user.id), "email": user.email},
+        data={"sub": str(user["id"]), "email": user["email"]},
         expires_delta=access_token_expires
     )
 
@@ -114,6 +132,6 @@ def login(login_data: LoginRequest, db: Session = Depends(get_db)):
 
 
 @router.get("/me", response_model=UserResponse)
-def get_me(current_user: User = Depends(get_current_user)):
+def get_me(current_user: Dict[str, Any] = Depends(get_current_user)):
     """現在のユーザー情報を取得"""
     return current_user

--- a/backend/app/api/masters.py
+++ b/backend/app/api/masters.py
@@ -66,7 +66,7 @@ def create_shinchoku(
 
     new_item = {
         "id": str(uuid.uuid4()),
-        **data.model_dump()
+        **data.model_dump(mode="json")
     }
     response = db.table("master_shinchoku").insert(new_item).execute()
 
@@ -122,7 +122,7 @@ def update_shinchoku(
             )
 
     # 更新
-    update_data = data.model_dump(exclude_unset=True)
+    update_data = data.model_dump(exclude_unset=True, mode="json")
     response = db.table("master_shinchoku").update(update_data).eq("id", str(item_id)).execute()
 
     if not response.data:
@@ -188,7 +188,7 @@ def create_sagyou_kubun(
 
     new_item = {
         "id": str(uuid.uuid4()),
-        **data.model_dump()
+        **data.model_dump(mode="json")
     }
     response = db.table("master_sagyou_kubun").insert(new_item).execute()
 
@@ -243,7 +243,7 @@ def update_sagyou_kubun(
                 detail="この作業区分名は既に登録されています"
             )
 
-    update_data = data.model_dump(exclude_unset=True)
+    update_data = data.model_dump(exclude_unset=True, mode="json")
     response = db.table("master_sagyou_kubun").update(update_data).eq("id", str(item_id)).execute()
 
     if not response.data:
@@ -309,7 +309,7 @@ def create_toiawase(
 
     new_item = {
         "id": str(uuid.uuid4()),
-        **data.model_dump()
+        **data.model_dump(mode="json")
     }
     response = db.table("master_toiawase").insert(new_item).execute()
 
@@ -364,7 +364,7 @@ def update_toiawase(
                 detail="このステータス名は既に登録されています"
             )
 
-    update_data = data.model_dump(exclude_unset=True)
+    update_data = data.model_dump(exclude_unset=True, mode="json")
     response = db.table("master_toiawase").update(update_data).eq("id", str(item_id)).execute()
 
     if not response.data:
@@ -430,7 +430,7 @@ def create_machine_series(
 
     new_item = {
         "id": str(uuid.uuid4()),
-        **data.model_dump()
+        **data.model_dump(mode="json")
     }
     response = db.table("machine_series_master").insert(new_item).execute()
 
@@ -485,7 +485,7 @@ def update_machine_series(
                 detail="このシリーズ名は既に登録されています"
             )
 
-    update_data = data.model_dump(exclude_unset=True)
+    update_data = data.model_dump(exclude_unset=True, mode="json")
     response = db.table("machine_series_master").update(update_data).eq("id", str(item_id)).execute()
 
     if not response.data:

--- a/backend/app/api/masters.py
+++ b/backend/app/api/masters.py
@@ -5,19 +5,13 @@
 """
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.orm import Session
-from typing import List
+from supabase import Client
+from typing import List, Dict, Any
 from uuid import UUID
+import uuid
 
 from app.core.database import get_db
 from app.api.auth import get_current_user
-from app.models.user import User
-from app.models.master import (
-    MasterShinchoku,
-    MasterSagyouKubun,
-    MasterToiawase,
-    MachineSeriesMaster
-)
 from app.schemas.master import (
     MasterShinchokuCreate,
     MasterShinchokuUpdate,
@@ -43,109 +37,118 @@ def list_shinchoku(
     skip: int = 0,
     limit: int = 100,
     include_inactive: bool = False,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """進捗マスタ一覧取得"""
-    query = db.query(MasterShinchoku)
+    query = db.table("master_shinchoku").select("*")
     if not include_inactive:
-        query = query.filter(MasterShinchoku.is_active == True)
-    query = query.order_by(MasterShinchoku.sort_order)
-    return query.offset(skip).limit(limit).all()
+        query = query.eq("is_active", True)
+
+    response = query.order("sort_order").range(skip, skip + limit - 1).execute()
+    return response.data
 
 
 @router.post("/shinchoku", response_model=MasterShinchokuResponse, status_code=status.HTTP_201_CREATED)
 def create_shinchoku(
     data: MasterShinchokuCreate,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """進捗マスタ作成"""
     # 重複チェック
-    existing = db.query(MasterShinchoku).filter(
-        MasterShinchoku.status_name == data.status_name
-    ).first()
-    if existing:
+    existing = db.table("master_shinchoku").select("id").eq("status_name", data.status_name).execute()
+    if existing.data:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="このステータス名は既に登録されています"
         )
 
-    new_item = MasterShinchoku(**data.model_dump())
-    db.add(new_item)
-    db.commit()
-    db.refresh(new_item)
-    return new_item
+    new_item = {
+        "id": str(uuid.uuid4()),
+        **data.model_dump()
+    }
+    response = db.table("master_shinchoku").insert(new_item).execute()
+
+    if not response.data:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="進捗マスタの作成に失敗しました"
+        )
+
+    return response.data[0]
 
 
 @router.get("/shinchoku/{item_id}", response_model=MasterShinchokuResponse)
 def get_shinchoku(
     item_id: UUID,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """進捗マスタ詳細取得"""
-    item = db.query(MasterShinchoku).filter(MasterShinchoku.id == item_id).first()
-    if not item:
+    response = db.table("master_shinchoku").select("*").eq("id", str(item_id)).execute()
+    if not response.data:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="進捗マスタが見つかりません"
         )
-    return item
+    return response.data[0]
 
 
 @router.put("/shinchoku/{item_id}", response_model=MasterShinchokuResponse)
 def update_shinchoku(
     item_id: UUID,
     data: MasterShinchokuUpdate,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """進捗マスタ更新"""
-    item = db.query(MasterShinchoku).filter(MasterShinchoku.id == item_id).first()
-    if not item:
+    item_response = db.table("master_shinchoku").select("*").eq("id", str(item_id)).execute()
+    if not item_response.data:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="進捗マスタが見つかりません"
         )
 
+    item = item_response.data[0]
+
     # 重複チェック（status_nameが更新される場合）
-    if data.status_name and data.status_name != item.status_name:
-        existing = db.query(MasterShinchoku).filter(
-            MasterShinchoku.status_name == data.status_name,
-            MasterShinchoku.id != item_id
-        ).first()
-        if existing:
+    if data.status_name and data.status_name != item["status_name"]:
+        existing = db.table("master_shinchoku").select("id").eq("status_name", data.status_name).neq("id", str(item_id)).execute()
+        if existing.data:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="このステータス名は既に登録されています"
             )
 
     # 更新
-    for field, value in data.model_dump(exclude_unset=True).items():
-        setattr(item, field, value)
+    update_data = data.model_dump(exclude_unset=True)
+    response = db.table("master_shinchoku").update(update_data).eq("id", str(item_id)).execute()
 
-    db.commit()
-    db.refresh(item)
-    return item
+    if not response.data:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="進捗マスタの更新に失敗しました"
+        )
+
+    return response.data[0]
 
 
 @router.delete("/shinchoku/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_shinchoku(
     item_id: UUID,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """進捗マスタ論理削除"""
-    item = db.query(MasterShinchoku).filter(MasterShinchoku.id == item_id).first()
-    if not item:
+    item_response = db.table("master_shinchoku").select("id").eq("id", str(item_id)).execute()
+    if not item_response.data:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="進捗マスタが見つかりません"
         )
 
-    item.is_active = False
-    db.commit()
+    db.table("master_shinchoku").update({"is_active": False}).eq("id", str(item_id)).execute()
     return None
 
 
@@ -156,108 +159,117 @@ def list_sagyou_kubun(
     skip: int = 0,
     limit: int = 100,
     include_inactive: bool = False,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """作業区分マスタ一覧取得"""
-    query = db.query(MasterSagyouKubun)
+    query = db.table("master_sagyou_kubun").select("*")
     if not include_inactive:
-        query = query.filter(MasterSagyouKubun.is_active == True)
-    query = query.order_by(MasterSagyouKubun.sort_order)
-    return query.offset(skip).limit(limit).all()
+        query = query.eq("is_active", True)
+
+    response = query.order("sort_order").range(skip, skip + limit - 1).execute()
+    return response.data
 
 
 @router.post("/sagyou-kubun", response_model=MasterSagyouKubunResponse, status_code=status.HTTP_201_CREATED)
 def create_sagyou_kubun(
     data: MasterSagyouKubunCreate,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """作業区分マスタ作成"""
     # 重複チェック
-    existing = db.query(MasterSagyouKubun).filter(
-        MasterSagyouKubun.kubun_name == data.kubun_name
-    ).first()
-    if existing:
+    existing = db.table("master_sagyou_kubun").select("id").eq("kubun_name", data.kubun_name).execute()
+    if existing.data:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="この作業区分名は既に登録されています"
         )
 
-    new_item = MasterSagyouKubun(**data.model_dump())
-    db.add(new_item)
-    db.commit()
-    db.refresh(new_item)
-    return new_item
+    new_item = {
+        "id": str(uuid.uuid4()),
+        **data.model_dump()
+    }
+    response = db.table("master_sagyou_kubun").insert(new_item).execute()
+
+    if not response.data:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="作業区分マスタの作成に失敗しました"
+        )
+
+    return response.data[0]
 
 
 @router.get("/sagyou-kubun/{item_id}", response_model=MasterSagyouKubunResponse)
 def get_sagyou_kubun(
     item_id: UUID,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """作業区分マスタ詳細取得"""
-    item = db.query(MasterSagyouKubun).filter(MasterSagyouKubun.id == item_id).first()
-    if not item:
+    response = db.table("master_sagyou_kubun").select("*").eq("id", str(item_id)).execute()
+    if not response.data:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="作業区分マスタが見つかりません"
         )
-    return item
+    return response.data[0]
 
 
 @router.put("/sagyou-kubun/{item_id}", response_model=MasterSagyouKubunResponse)
 def update_sagyou_kubun(
     item_id: UUID,
     data: MasterSagyouKubunUpdate,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """作業区分マスタ更新"""
-    item = db.query(MasterSagyouKubun).filter(MasterSagyouKubun.id == item_id).first()
-    if not item:
+    item_response = db.table("master_sagyou_kubun").select("*").eq("id", str(item_id)).execute()
+    if not item_response.data:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="作業区分マスタが見つかりません"
         )
 
+    item = item_response.data[0]
+
     # 重複チェック
-    if data.kubun_name and data.kubun_name != item.kubun_name:
-        existing = db.query(MasterSagyouKubun).filter(
-            MasterSagyouKubun.kubun_name == data.kubun_name,
-            MasterSagyouKubun.id != item_id
-        ).first()
-        if existing:
+    if data.kubun_name and data.kubun_name != item["kubun_name"]:
+        existing = db.table("master_sagyou_kubun").select("id").eq("kubun_name", data.kubun_name).neq("id", str(item_id)).execute()
+        if existing.data:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="この作業区分名は既に登録されています"
             )
 
-    for field, value in data.model_dump(exclude_unset=True).items():
-        setattr(item, field, value)
+    update_data = data.model_dump(exclude_unset=True)
+    response = db.table("master_sagyou_kubun").update(update_data).eq("id", str(item_id)).execute()
 
-    db.commit()
-    db.refresh(item)
-    return item
+    if not response.data:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="作業区分マスタの更新に失敗しました"
+        )
+
+    return response.data[0]
 
 
 @router.delete("/sagyou-kubun/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_sagyou_kubun(
     item_id: UUID,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """作業区分マスタ論理削除"""
-    item = db.query(MasterSagyouKubun).filter(MasterSagyouKubun.id == item_id).first()
-    if not item:
+    item_response = db.table("master_sagyou_kubun").select("id").eq("id", str(item_id)).execute()
+    if not item_response.data:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="作業区分マスタが見つかりません"
         )
 
-    item.is_active = False
-    db.commit()
+    db.table("master_sagyou_kubun").update({"is_active": False}).eq("id", str(item_id)).execute()
     return None
 
 
@@ -268,108 +280,117 @@ def list_toiawase(
     skip: int = 0,
     limit: int = 100,
     include_inactive: bool = False,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """問い合わせマスタ一覧取得"""
-    query = db.query(MasterToiawase)
+    query = db.table("master_toiawase").select("*")
     if not include_inactive:
-        query = query.filter(MasterToiawase.is_active == True)
-    query = query.order_by(MasterToiawase.sort_order)
-    return query.offset(skip).limit(limit).all()
+        query = query.eq("is_active", True)
+
+    response = query.order("sort_order").range(skip, skip + limit - 1).execute()
+    return response.data
 
 
 @router.post("/toiawase", response_model=MasterToiawaseResponse, status_code=status.HTTP_201_CREATED)
 def create_toiawase(
     data: MasterToiawaseCreate,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """問い合わせマスタ作成"""
     # 重複チェック
-    existing = db.query(MasterToiawase).filter(
-        MasterToiawase.status_name == data.status_name
-    ).first()
-    if existing:
+    existing = db.table("master_toiawase").select("id").eq("status_name", data.status_name).execute()
+    if existing.data:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="このステータス名は既に登録されています"
         )
 
-    new_item = MasterToiawase(**data.model_dump())
-    db.add(new_item)
-    db.commit()
-    db.refresh(new_item)
-    return new_item
+    new_item = {
+        "id": str(uuid.uuid4()),
+        **data.model_dump()
+    }
+    response = db.table("master_toiawase").insert(new_item).execute()
+
+    if not response.data:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="問い合わせマスタの作成に失敗しました"
+        )
+
+    return response.data[0]
 
 
 @router.get("/toiawase/{item_id}", response_model=MasterToiawaseResponse)
 def get_toiawase(
     item_id: UUID,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """問い合わせマスタ詳細取得"""
-    item = db.query(MasterToiawase).filter(MasterToiawase.id == item_id).first()
-    if not item:
+    response = db.table("master_toiawase").select("*").eq("id", str(item_id)).execute()
+    if not response.data:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="問い合わせマスタが見つかりません"
         )
-    return item
+    return response.data[0]
 
 
 @router.put("/toiawase/{item_id}", response_model=MasterToiawaseResponse)
 def update_toiawase(
     item_id: UUID,
     data: MasterToiawaseUpdate,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """問い合わせマスタ更新"""
-    item = db.query(MasterToiawase).filter(MasterToiawase.id == item_id).first()
-    if not item:
+    item_response = db.table("master_toiawase").select("*").eq("id", str(item_id)).execute()
+    if not item_response.data:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="問い合わせマスタが見つかりません"
         )
 
+    item = item_response.data[0]
+
     # 重複チェック
-    if data.status_name and data.status_name != item.status_name:
-        existing = db.query(MasterToiawase).filter(
-            MasterToiawase.status_name == data.status_name,
-            MasterToiawase.id != item_id
-        ).first()
-        if existing:
+    if data.status_name and data.status_name != item["status_name"]:
+        existing = db.table("master_toiawase").select("id").eq("status_name", data.status_name).neq("id", str(item_id)).execute()
+        if existing.data:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="このステータス名は既に登録されています"
             )
 
-    for field, value in data.model_dump(exclude_unset=True).items():
-        setattr(item, field, value)
+    update_data = data.model_dump(exclude_unset=True)
+    response = db.table("master_toiawase").update(update_data).eq("id", str(item_id)).execute()
 
-    db.commit()
-    db.refresh(item)
-    return item
+    if not response.data:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="問い合わせマスタの更新に失敗しました"
+        )
+
+    return response.data[0]
 
 
 @router.delete("/toiawase/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_toiawase(
     item_id: UUID,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """問い合わせマスタ論理削除"""
-    item = db.query(MasterToiawase).filter(MasterToiawase.id == item_id).first()
-    if not item:
+    item_response = db.table("master_toiawase").select("id").eq("id", str(item_id)).execute()
+    if not item_response.data:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="問い合わせマスタが見つかりません"
         )
 
-    item.is_active = False
-    db.commit()
+    db.table("master_toiawase").update({"is_active": False}).eq("id", str(item_id)).execute()
     return None
 
 
@@ -380,106 +401,115 @@ def list_machine_series(
     skip: int = 0,
     limit: int = 100,
     include_inactive: bool = False,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """機種シリーズマスタ一覧取得"""
-    query = db.query(MachineSeriesMaster)
+    query = db.table("machine_series_master").select("*")
     if not include_inactive:
-        query = query.filter(MachineSeriesMaster.is_active == True)
-    query = query.order_by(MachineSeriesMaster.sort_order)
-    return query.offset(skip).limit(limit).all()
+        query = query.eq("is_active", True)
+
+    response = query.order("sort_order").range(skip, skip + limit - 1).execute()
+    return response.data
 
 
 @router.post("/machine-series", response_model=MachineSeriesMasterResponse, status_code=status.HTTP_201_CREATED)
 def create_machine_series(
     data: MachineSeriesMasterCreate,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """機種シリーズマスタ作成"""
     # 重複チェック
-    existing = db.query(MachineSeriesMaster).filter(
-        MachineSeriesMaster.series_name == data.series_name
-    ).first()
-    if existing:
+    existing = db.table("machine_series_master").select("id").eq("series_name", data.series_name).execute()
+    if existing.data:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="このシリーズ名は既に登録されています"
         )
 
-    new_item = MachineSeriesMaster(**data.model_dump())
-    db.add(new_item)
-    db.commit()
-    db.refresh(new_item)
-    return new_item
+    new_item = {
+        "id": str(uuid.uuid4()),
+        **data.model_dump()
+    }
+    response = db.table("machine_series_master").insert(new_item).execute()
+
+    if not response.data:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="機種シリーズマスタの作成に失敗しました"
+        )
+
+    return response.data[0]
 
 
 @router.get("/machine-series/{item_id}", response_model=MachineSeriesMasterResponse)
 def get_machine_series(
     item_id: UUID,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """機種シリーズマスタ詳細取得"""
-    item = db.query(MachineSeriesMaster).filter(MachineSeriesMaster.id == item_id).first()
-    if not item:
+    response = db.table("machine_series_master").select("*").eq("id", str(item_id)).execute()
+    if not response.data:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="機種シリーズマスタが見つかりません"
         )
-    return item
+    return response.data[0]
 
 
 @router.put("/machine-series/{item_id}", response_model=MachineSeriesMasterResponse)
 def update_machine_series(
     item_id: UUID,
     data: MachineSeriesMasterUpdate,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """機種シリーズマスタ更新"""
-    item = db.query(MachineSeriesMaster).filter(MachineSeriesMaster.id == item_id).first()
-    if not item:
+    item_response = db.table("machine_series_master").select("*").eq("id", str(item_id)).execute()
+    if not item_response.data:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="機種シリーズマスタが見つかりません"
         )
 
+    item = item_response.data[0]
+
     # 重複チェック
-    if data.series_name and data.series_name != item.series_name:
-        existing = db.query(MachineSeriesMaster).filter(
-            MachineSeriesMaster.series_name == data.series_name,
-            MachineSeriesMaster.id != item_id
-        ).first()
-        if existing:
+    if data.series_name and data.series_name != item["series_name"]:
+        existing = db.table("machine_series_master").select("id").eq("series_name", data.series_name).neq("id", str(item_id)).execute()
+        if existing.data:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="このシリーズ名は既に登録されています"
             )
 
-    for field, value in data.model_dump(exclude_unset=True).items():
-        setattr(item, field, value)
+    update_data = data.model_dump(exclude_unset=True)
+    response = db.table("machine_series_master").update(update_data).eq("id", str(item_id)).execute()
 
-    db.commit()
-    db.refresh(item)
-    return item
+    if not response.data:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="機種シリーズマスタの更新に失敗しました"
+        )
+
+    return response.data[0]
 
 
 @router.delete("/machine-series/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_machine_series(
     item_id: UUID,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Client = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user)
 ):
     """機種シリーズマスタ論理削除"""
-    item = db.query(MachineSeriesMaster).filter(MachineSeriesMaster.id == item_id).first()
-    if not item:
+    item_response = db.table("machine_series_master").select("id").eq("id", str(item_id)).execute()
+    if not item_response.data:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="機種シリーズマスタが見つかりません"
         )
 
-    item.is_active = False
-    db.commit()
+    db.table("machine_series_master").update({"is_active": False}).eq("id", str(item_id)).execute()
     return None

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -5,20 +5,13 @@
 """
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy.orm import Session, joinedload
-from typing import Optional
+from supabase import Client
+from typing import Optional, Dict, Any, List
 from uuid import UUID
+import uuid
 
 from app.core.database import get_db
 from app.api.auth import get_current_user
-from app.models.user import User
-from app.models.project import Project
-from app.models.master import (
-    MasterShinchoku,
-    MasterSagyouKubun,
-    MasterToiawase,
-    MachineSeriesMaster
-)
 from app.schemas.project import (
     ProjectCreate,
     ProjectUpdate,
@@ -32,34 +25,37 @@ router = APIRouter(prefix="/api/projects", tags=["projects"])
 @router.post("", response_model=ProjectResponse, status_code=status.HTTP_201_CREATED)
 def create_project(
     project_data: ProjectCreate,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: Client = Depends(get_db),
 ):
     """案件を新規作成"""
     # 管理Noの重複チェック
-    existing = db.query(Project).filter(
-        Project.management_no == project_data.management_no,
-        Project.is_active == True
-    ).first()
-    if existing:
+    existing = db.table("projects").select("id").eq("management_no", project_data.management_no).eq("is_active", True).execute()
+    if existing.data:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="この管理Noは既に使用されています"
         )
 
     # 新規案件作成
-    db_project = Project(
+    new_project = {
+        "id": str(uuid.uuid4()),
         **project_data.model_dump(),
-        created_by=current_user.id,
-        actual_hours=0,
-        is_active=True,
-    )
-    db.add(db_project)
-    db.commit()
-    db.refresh(db_project)
+        "created_by": current_user["id"],
+        "actual_hours": 0,
+        "is_active": True,
+    }
+
+    response = db.table("projects").insert(new_project).execute()
+
+    if not response.data:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="案件の作成に失敗しました"
+        )
 
     # マスタ名称を取得
-    return _enrich_project_response(db, db_project)
+    return _enrich_project_response(db, response.data[0])
 
 
 @router.get("", response_model=ProjectListResponse)
@@ -71,40 +67,49 @@ def list_projects(
     machine_no: Optional[str] = Query(None, description="機番で検索"),
     management_no: Optional[str] = Query(None, description="管理Noで検索"),
     include_inactive: bool = Query(False, description="無効な案件も含める"),
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: Client = Depends(get_db),
 ):
     """案件一覧を取得"""
-    query = db.query(Project).options(
-        joinedload(Project.machine_series),
-        joinedload(Project.toiawase),
-        joinedload(Project.sagyou_kubun),
-        joinedload(Project.shinchoku)
-    )
+    # Supabaseクエリ構築
+    query = db.table("projects").select("*")
 
     # 論理削除フィルタ
     if not include_inactive:
-        query = query.filter(Project.is_active == True)
+        query = query.eq("is_active", True)
 
     # フィルタリング
     if shinchoku_id:
-        query = query.filter(Project.shinchoku_id == shinchoku_id)
+        query = query.eq("shinchoku_id", str(shinchoku_id))
     if sagyou_kubun_id:
-        query = query.filter(Project.sagyou_kubun_id == sagyou_kubun_id)
+        query = query.eq("sagyou_kubun_id", str(sagyou_kubun_id))
     if machine_no:
-        query = query.filter(Project.machine_no.contains(machine_no))
+        query = query.ilike("machine_no", f"%{machine_no}%")
     if management_no:
-        query = query.filter(Project.management_no.contains(management_no))
+        query = query.ilike("management_no", f"%{management_no}%")
 
-    # 総件数取得
-    total = query.count()
+    # 総件数取得（カウント用に別クエリ）
+    count_query = db.table("projects").select("id", count="exact")
+    if not include_inactive:
+        count_query = count_query.eq("is_active", True)
+    if shinchoku_id:
+        count_query = count_query.eq("shinchoku_id", str(shinchoku_id))
+    if sagyou_kubun_id:
+        count_query = count_query.eq("sagyou_kubun_id", str(sagyou_kubun_id))
+    if machine_no:
+        count_query = count_query.ilike("machine_no", f"%{machine_no}%")
+    if management_no:
+        count_query = count_query.ilike("management_no", f"%{management_no}%")
+
+    count_response = count_query.execute()
+    total = count_response.count if count_response.count is not None else 0
 
     # ページネーション
     offset = (page - 1) * per_page
-    projects = query.order_by(Project.created_at.desc()).offset(offset).limit(per_page).all()
+    projects_response = query.order("created_at", desc=True).range(offset, offset + per_page - 1).execute()
 
     # レスポンスにマスタ名称を追加
-    enriched_projects = [_enrich_project_response(db, p) for p in projects]
+    enriched_projects = [_enrich_project_response(db, p) for p in projects_response.data]
 
     return ProjectListResponse(
         projects=enriched_projects,
@@ -117,49 +122,42 @@ def list_projects(
 @router.get("/{project_id}", response_model=ProjectResponse)
 def get_project(
     project_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: Client = Depends(get_db),
 ):
     """案件詳細を取得"""
-    project = db.query(Project).options(
-        joinedload(Project.machine_series),
-        joinedload(Project.toiawase),
-        joinedload(Project.sagyou_kubun),
-        joinedload(Project.shinchoku)
-    ).filter(Project.id == project_id).first()
+    response = db.table("projects").select("*").eq("id", str(project_id)).execute()
 
-    if not project:
+    if not response.data:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="案件が見つかりません"
         )
 
-    return _enrich_project_response(db, project)
+    return _enrich_project_response(db, response.data[0])
 
 
 @router.put("/{project_id}", response_model=ProjectResponse)
 def update_project(
     project_id: UUID,
     project_data: ProjectUpdate,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: Client = Depends(get_db),
 ):
     """案件を更新"""
-    project = db.query(Project).filter(Project.id == project_id).first()
-    if not project:
+    project_response = db.table("projects").select("*").eq("id", str(project_id)).execute()
+    if not project_response.data:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="案件が見つかりません"
         )
 
+    project = project_response.data[0]
+
     # 管理Noの重複チェック（変更される場合）
-    if project_data.management_no and project_data.management_no != project.management_no:
-        existing = db.query(Project).filter(
-            Project.management_no == project_data.management_no,
-            Project.is_active == True,
-            Project.id != project_id
-        ).first()
-        if existing:
+    if project_data.management_no and project_data.management_no != project["management_no"]:
+        existing = db.table("projects").select("id").eq("management_no", project_data.management_no).eq("is_active", True).neq("id", str(project_id)).execute()
+        if existing.data:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="この管理Noは既に使用されています"
@@ -167,62 +165,69 @@ def update_project(
 
     # 更新
     update_data = project_data.model_dump(exclude_unset=True)
-    for key, value in update_data.items():
-        setattr(project, key, value)
+    response = db.table("projects").update(update_data).eq("id", str(project_id)).execute()
 
-    db.commit()
-    db.refresh(project)
+    if not response.data:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="案件の更新に失敗しました"
+        )
 
-    return _enrich_project_response(db, project)
+    return _enrich_project_response(db, response.data[0])
 
 
 @router.delete("/{project_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_project(
     project_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: Client = Depends(get_db),
 ):
     """案件を論理削除"""
-    project = db.query(Project).filter(Project.id == project_id).first()
-    if not project:
+    project_response = db.table("projects").select("id").eq("id", str(project_id)).execute()
+    if not project_response.data:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="案件が見つかりません"
         )
 
     # 論理削除
-    project.is_active = False
-    db.commit()
+    db.table("projects").update({"is_active": False}).eq("id", str(project_id)).execute()
     return None
 
 
-def _enrich_project_response(db: Session, project: Project) -> ProjectResponse:
+def _enrich_project_response(db: Client, project: Dict[str, Any]) -> ProjectResponse:
     """案件レスポンスにマスタ名称を追加"""
+    # マスタ名称を取得
+    machine_series_name = None
+    if project.get("machine_series_id"):
+        ms_response = db.table("machine_series_master").select("display_name").eq("id", project["machine_series_id"]).execute()
+        if ms_response.data:
+            machine_series_name = ms_response.data[0]["display_name"]
+
+    toiawase_name = None
+    if project.get("toiawase_id"):
+        ta_response = db.table("master_toiawase").select("status_name").eq("id", project["toiawase_id"]).execute()
+        if ta_response.data:
+            toiawase_name = ta_response.data[0]["status_name"]
+
+    sagyou_kubun_name = None
+    if project.get("sagyou_kubun_id"):
+        sk_response = db.table("master_sagyou_kubun").select("kubun_name").eq("id", project["sagyou_kubun_id"]).execute()
+        if sk_response.data:
+            sagyou_kubun_name = sk_response.data[0]["kubun_name"]
+
+    shinchoku_name = None
+    if project.get("shinchoku_id"):
+        sc_response = db.table("master_shinchoku").select("status_name").eq("id", project["shinchoku_id"]).execute()
+        if sc_response.data:
+            shinchoku_name = sc_response.data[0]["status_name"]
+
     response_data = {
-        "id": project.id,
-        "management_no": project.management_no,
-        "machine_series_id": project.machine_series_id,
-        "generation": project.generation,
-        "tonnage": project.tonnage,
-        "spec_tags": project.spec_tags,
-        "machine_no": project.machine_no,
-        "commission_content": project.commission_content,
-        "toiawase_id": project.toiawase_id,
-        "sagyou_kubun_id": project.sagyou_kubun_id,
-        "estimated_hours": project.estimated_hours,
-        "actual_hours": project.actual_hours,
-        "shinchoku_id": project.shinchoku_id,
-        "start_date": project.start_date,
-        "completion_date": project.completion_date,
-        "drawing_deadline": project.drawing_deadline,
-        "is_active": project.is_active,
-        "created_by": project.created_by,
-        "created_at": project.created_at,
-        "updated_at": project.updated_at,
-        "machine_series_name": project.machine_series.display_name if project.machine_series else None,
-        "toiawase_name": project.toiawase.status_name if project.toiawase else None,
-        "sagyou_kubun_name": project.sagyou_kubun.kubun_name if project.sagyou_kubun else None,
-        "shinchoku_name": project.shinchoku.status_name if project.shinchoku else None,
+        **project,
+        "machine_series_name": machine_series_name,
+        "toiawase_name": toiawase_name,
+        "sagyou_kubun_name": sagyou_kubun_name,
+        "shinchoku_name": shinchoku_name,
     }
 
     return ProjectResponse(**response_data)

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -40,7 +40,7 @@ def create_project(
     # 新規案件作成
     new_project = {
         "id": str(uuid.uuid4()),
-        **project_data.model_dump(),
+        **project_data.model_dump(mode="json"),
         "created_by": current_user["id"],
         "actual_hours": 0,
         "is_active": True,
@@ -164,7 +164,7 @@ def update_project(
             )
 
     # 更新
-    update_data = project_data.model_dump(exclude_unset=True)
+    update_data = project_data.model_dump(exclude_unset=True, mode="json")
     response = db.table("projects").update(update_data).eq("id", str(project_id)).execute()
 
     if not response.data:

--- a/backend/app/api/worklogs.py
+++ b/backend/app/api/worklogs.py
@@ -34,7 +34,7 @@ def create_worklog(
     # 新規工数入力作成
     new_worklog = {
         "id": str(uuid.uuid4()),
-        **worklog_data.model_dump(),
+        **worklog_data.model_dump(mode="json"),
         "user_id": current_user["id"],
     }
 
@@ -127,7 +127,7 @@ def update_worklog(
     old_duration = worklog["duration_minutes"]
 
     # 更新データ
-    update_data = worklog_data.model_dump(exclude_unset=True)
+    update_data = worklog_data.model_dump(exclude_unset=True, mode="json")
     new_duration = update_data.get("duration_minutes", old_duration)
 
     # 作業時間が変更される場合、案件の実績工数を調整

--- a/backend/app/api/worklogs.py
+++ b/backend/app/api/worklogs.py
@@ -1,15 +1,12 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy.orm import Session
-from sqlalchemy import func
-from typing import Optional
+from supabase import Client
+from typing import Optional, Dict, Any
 from uuid import UUID
+import uuid
 from datetime import date
 
 from app.core.database import get_db
 from app.api.auth import get_current_user
-from app.models.user import User
-from app.models.worklog import WorkLog
-from app.models.project import Project
 from app.schemas.worklog import (
     WorkLogCreate,
     WorkLogUpdate,
@@ -23,28 +20,37 @@ router = APIRouter()
 @router.post("", response_model=WorkLogResponse, status_code=201)
 def create_worklog(
     worklog_data: WorkLogCreate,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: Client = Depends(get_db),
 ):
     """工数入力を新規作成"""
     # 案件の存在確認
-    project = db.query(Project).filter(Project.id == worklog_data.project_id).first()
-    if not project:
+    project_response = db.table("projects").select("id, actual_hours").eq("id", str(worklog_data.project_id)).execute()
+    if not project_response.data:
         raise HTTPException(status_code=404, detail="案件が見つかりません")
 
+    project = project_response.data[0]
+
     # 新規工数入力作成
-    db_worklog = WorkLog(
+    new_worklog = {
+        "id": str(uuid.uuid4()),
         **worklog_data.model_dump(),
-        user_id=current_user.id,
-    )
-    db.add(db_worklog)
+        "user_id": current_user["id"],
+    }
+
+    worklog_response = db.table("worklogs").insert(new_worklog).execute()
+
+    if not worklog_response.data:
+        raise HTTPException(
+            status_code=500,
+            detail="工数入力の作成に失敗しました"
+        )
 
     # 案件の実績工数を更新
-    project.actual_hours += worklog_data.duration_minutes
+    new_actual_hours = (project.get("actual_hours") or 0) + worklog_data.duration_minutes
+    db.table("projects").update({"actual_hours": new_actual_hours}).eq("id", str(worklog_data.project_id)).execute()
 
-    db.commit()
-    db.refresh(db_worklog)
-    return db_worklog
+    return worklog_response.data[0]
 
 
 @router.get("", response_model=WorkLogListResponse)
@@ -54,29 +60,38 @@ def list_worklogs(
     project_id: Optional[UUID] = Query(None, description="案件IDでフィルタ"),
     work_date: Optional[date] = Query(None, description="作業日でフィルタ"),
     user_id: Optional[UUID] = Query(None, description="ユーザーIDでフィルタ"),
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: Client = Depends(get_db),
 ):
     """工数入力一覧を取得"""
-    query = db.query(WorkLog)
+    query = db.table("worklogs").select("*")
 
     # フィルタリング
     if project_id:
-        query = query.filter(WorkLog.project_id == project_id)
+        query = query.eq("project_id", str(project_id))
     if work_date:
-        query = query.filter(WorkLog.work_date == work_date)
+        query = query.eq("work_date", work_date.isoformat())
     if user_id:
-        query = query.filter(WorkLog.user_id == user_id)
+        query = query.eq("user_id", str(user_id))
 
     # 総件数取得
-    total = query.count()
+    count_query = db.table("worklogs").select("id", count="exact")
+    if project_id:
+        count_query = count_query.eq("project_id", str(project_id))
+    if work_date:
+        count_query = count_query.eq("work_date", work_date.isoformat())
+    if user_id:
+        count_query = count_query.eq("user_id", str(user_id))
+
+    count_response = count_query.execute()
+    total = count_response.count if count_response.count is not None else 0
 
     # ページネーション
     offset = (page - 1) * per_page
-    worklogs = query.order_by(WorkLog.work_date.desc(), WorkLog.created_at.desc()).offset(offset).limit(per_page).all()
+    worklogs_response = query.order("work_date", desc=True).order("created_at", desc=True).range(offset, offset + per_page - 1).execute()
 
     return WorkLogListResponse(
-        worklogs=worklogs,
+        worklogs=worklogs_response.data,
         total=total,
         page=page,
         per_page=per_page,
@@ -86,125 +101,137 @@ def list_worklogs(
 @router.get("/{worklog_id}", response_model=WorkLogResponse)
 def get_worklog(
     worklog_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: Client = Depends(get_db),
 ):
     """工数入力詳細を取得"""
-    worklog = db.query(WorkLog).filter(WorkLog.id == worklog_id).first()
-    if not worklog:
+    response = db.table("worklogs").select("*").eq("id", str(worklog_id)).execute()
+    if not response.data:
         raise HTTPException(status_code=404, detail="工数入力が見つかりません")
-    return worklog
+    return response.data[0]
 
 
 @router.put("/{worklog_id}", response_model=WorkLogResponse)
 def update_worklog(
     worklog_id: UUID,
     worklog_data: WorkLogUpdate,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: Client = Depends(get_db),
 ):
     """工数入力を更新"""
-    worklog = db.query(WorkLog).filter(WorkLog.id == worklog_id).first()
-    if not worklog:
+    worklog_response = db.table("worklogs").select("*").eq("id", str(worklog_id)).execute()
+    if not worklog_response.data:
         raise HTTPException(status_code=404, detail="工数入力が見つかりません")
 
-    # 作業時間が変更される場合、案件の実績工数を調整
-    old_duration = worklog.duration_minutes
+    worklog = worklog_response.data[0]
+    old_duration = worklog["duration_minutes"]
+
+    # 更新データ
     update_data = worklog_data.model_dump(exclude_unset=True)
     new_duration = update_data.get("duration_minutes", old_duration)
 
+    # 作業時間が変更される場合、案件の実績工数を調整
     if new_duration != old_duration:
-        project = db.query(Project).filter(Project.id == worklog.project_id).first()
-        if project:
-            project.actual_hours = project.actual_hours - old_duration + new_duration
+        project_response = db.table("projects").select("actual_hours").eq("id", worklog["project_id"]).execute()
+        if project_response.data:
+            project = project_response.data[0]
+            new_actual_hours = (project.get("actual_hours") or 0) - old_duration + new_duration
+            db.table("projects").update({"actual_hours": new_actual_hours}).eq("id", worklog["project_id"]).execute()
 
     # 更新
-    for key, value in update_data.items():
-        setattr(worklog, key, value)
+    response = db.table("worklogs").update(update_data).eq("id", str(worklog_id)).execute()
 
-    db.commit()
-    db.refresh(worklog)
-    return worklog
+    if not response.data:
+        raise HTTPException(status_code=500, detail="工数入力の更新に失敗しました")
+
+    return response.data[0]
 
 
 @router.delete("/{worklog_id}", status_code=204)
 def delete_worklog(
     worklog_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: Client = Depends(get_db),
 ):
     """工数入力を削除"""
-    worklog = db.query(WorkLog).filter(WorkLog.id == worklog_id).first()
-    if not worklog:
+    worklog_response = db.table("worklogs").select("*").eq("id", str(worklog_id)).execute()
+    if not worklog_response.data:
         raise HTTPException(status_code=404, detail="工数入力が見つかりません")
 
-    # 案件の実績工数を減算
-    project = db.query(Project).filter(Project.id == worklog.project_id).first()
-    if project:
-        project.actual_hours -= worklog.duration_minutes
+    worklog = worklog_response.data[0]
 
-    db.delete(worklog)
-    db.commit()
+    # 案件の実績工数を減算
+    project_response = db.table("projects").select("actual_hours").eq("id", worklog["project_id"]).execute()
+    if project_response.data:
+        project = project_response.data[0]
+        new_actual_hours = (project.get("actual_hours") or 0) - worklog["duration_minutes"]
+        db.table("projects").update({"actual_hours": new_actual_hours}).eq("id", worklog["project_id"]).execute()
+
+    # 削除
+    db.table("worklogs").delete().eq("id", str(worklog_id)).execute()
     return None
 
 
 @router.get("/summary/{project_id}")
 def get_worklog_summary(
     project_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: Client = Depends(get_db),
 ):
     """案件の工数集計を取得"""
     # 案件の存在確認
-    project = db.query(Project).filter(Project.id == project_id).first()
-    if not project:
+    project_response = db.table("projects").select("management_no, estimated_hours, actual_hours").eq("id", str(project_id)).execute()
+    if not project_response.data:
         raise HTTPException(status_code=404, detail="案件が見つかりません")
 
-    # ユーザー別工数集計
-    user_summary = (
-        db.query(
-            User.username,
-            func.sum(WorkLog.duration_minutes).label("total_minutes"),
-            func.count(WorkLog.id).label("entry_count"),
-        )
-        .join(WorkLog, WorkLog.user_id == User.id)
-        .filter(WorkLog.project_id == project_id)
-        .group_by(User.id, User.username)
-        .all()
-    )
+    project = project_response.data[0]
 
-    # 日別工数集計
-    daily_summary = (
-        db.query(
-            WorkLog.work_date,
-            func.sum(WorkLog.duration_minutes).label("total_minutes"),
-            func.count(WorkLog.id).label("entry_count"),
-        )
-        .filter(WorkLog.project_id == project_id)
-        .group_by(WorkLog.work_date)
-        .order_by(WorkLog.work_date.desc())
-        .all()
-    )
+    # 全工数データを取得
+    worklogs_response = db.table("worklogs").select("user_id, duration_minutes, work_date").eq("project_id", str(project_id)).execute()
+    worklogs = worklogs_response.data
+
+    # ユーザー名を取得
+    user_ids = list(set([w["user_id"] for w in worklogs]))
+    users_map = {}
+    if user_ids:
+        users_response = db.table("users").select("id, username").in_("id", user_ids).execute()
+        users_map = {u["id"]: u["username"] for u in users_response.data}
+
+    # ユーザー別集計
+    user_summary_dict = {}
+    for worklog in worklogs:
+        user_id = worklog["user_id"]
+        if user_id not in user_summary_dict:
+            user_summary_dict[user_id] = {
+                "username": users_map.get(user_id, "Unknown"),
+                "total_minutes": 0,
+                "entry_count": 0
+            }
+        user_summary_dict[user_id]["total_minutes"] += worklog["duration_minutes"]
+        user_summary_dict[user_id]["entry_count"] += 1
+
+    user_summary = list(user_summary_dict.values())
+
+    # 日別集計
+    daily_summary_dict = {}
+    for worklog in worklogs:
+        work_date = worklog["work_date"]
+        if work_date not in daily_summary_dict:
+            daily_summary_dict[work_date] = {
+                "work_date": work_date,
+                "total_minutes": 0,
+                "entry_count": 0
+            }
+        daily_summary_dict[work_date]["total_minutes"] += worklog["duration_minutes"]
+        daily_summary_dict[work_date]["entry_count"] += 1
+
+    daily_summary = sorted(daily_summary_dict.values(), key=lambda x: x["work_date"], reverse=True)
 
     return {
-        "project_id": project_id,
-        "management_no": project.management_no,
-        "estimated_hours": project.estimated_hours or 0,
-        "actual_hours": project.actual_hours,
-        "by_user": [
-            {
-                "username": row.username,
-                "total_minutes": row.total_minutes,
-                "entry_count": row.entry_count,
-            }
-            for row in user_summary
-        ],
-        "by_date": [
-            {
-                "work_date": row.work_date.isoformat(),
-                "total_minutes": row.total_minutes,
-                "entry_count": row.entry_count,
-            }
-            for row in daily_summary
-        ],
+        "project_id": str(project_id),
+        "management_no": project["management_no"],
+        "estimated_hours": project.get("estimated_hours") or 0,
+        "actual_hours": project.get("actual_hours") or 0,
+        "by_user": user_summary,
+        "by_date": daily_summary,
     }

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,10 +1,15 @@
 from pydantic_settings import BaseSettings
 from typing import Optional
+from pydantic import ConfigDict
 
 
 class Settings(BaseSettings):
     # Database
     DATABASE_URL: str = "postgresql://nissei:nissei_dev_password@localhost:5432/nissei_db"
+
+    # Supabase (オプション、今後のAuth/Storage連携用)
+    SUPABASE_URL: Optional[str] = None
+    SUPABASE_ANON_KEY: Optional[str] = None
 
     # JWT
     JWT_SECRET_KEY: str = "your-secret-key-change-in-production"
@@ -21,9 +26,11 @@ class Settings(BaseSettings):
     # CORS
     CORS_ORIGINS: list = ["http://localhost:3000"]
 
-    class Config:
-        env_file = ".env"
-        case_sensitive = True
+    model_config = ConfigDict(
+        env_file=".env",
+        case_sensitive=True,
+        extra="ignore"  # 追加フィールドを無視
+    )
 
 
 settings = Settings()

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,22 +1,20 @@
-from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from supabase import create_client, Client
 from app.core.config import settings
 
-engine = create_engine(
-    settings.DATABASE_URL,
-    pool_pre_ping=True,
-    echo=True
-)
-
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-Base = declarative_base()
+# Supabase Clientのシングルトン
+_supabase_client: Client = None
 
 
-def get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
+def get_supabase_client() -> Client:
+    """Supabase Clientを取得（シングルトン）"""
+    global _supabase_client
+    if _supabase_client is None:
+        if not settings.SUPABASE_URL or not settings.SUPABASE_ANON_KEY:
+            raise ValueError("SUPABASE_URL and SUPABASE_ANON_KEY must be set in environment variables")
+        _supabase_client = create_client(settings.SUPABASE_URL, settings.SUPABASE_ANON_KEY)
+    return _supabase_client
+
+
+def get_db() -> Client:
+    """FastAPI Dependency用のSupabase Client取得関数"""
+    return get_supabase_client()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,9 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
-from app.core.database import engine, Base
 from app.api import auth, projects, worklogs, invoices, materials, checklists, masters
 
-# Create database tables
-Base.metadata.create_all(bind=engine)
+# Supabase Clientを使用するため、テーブル作成は不要（Supabase側で管理）
 
 app = FastAPI(
     title="Nissei 工数管理システム",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,13 +1,12 @@
 fastapi==0.104.1
 uvicorn[standard]==0.24.0
-sqlalchemy==2.0.23
-psycopg2-binary==2.9.9
+supabase==2.10.0
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
+bcrypt==4.0.1
 python-multipart==0.0.6
 pydantic==2.5.0
 pydantic-settings==2.1.0
-alembic==1.12.1
 minio==7.2.0
 PyPDF2==3.0.1
 pytesseract==0.3.10


### PR DESCRIPTION
## 概要
Phase 2の案件管理機能実装とデータベースのSupabase移行を完了しました。

## 主な変更内容

### Phase 2 案件管理機能
- 案件の登録・一覧・詳細・更新・削除（論理削除）機能
- マスタ管理機能（進捗、作業区分、問合せ、機番シリーズ）
- フィルタリング・ページネーション対応
- マスタ名称の自動付与

### Supabase移行
- **アーキテクチャ変更**: SQLAlchemy ORM → Supabase Python Client (v2.10.0)
- **データベース**: PostgreSQL (ローカル) → Supabase (クラウド)
- **移行対象**: 全10テーブル (users, projects, worklogs, materials, checklists, 4つのマスタテーブル)
- **APIエンドポイント**: 認証、案件管理、工数入力、マスタ管理すべてをSupabase対応に更新

### 技術的な改善
- bcrypt互換性問題の解決 (bcrypt==4.0.1追加)
- Pydantic v2対応 (config.py修正)
- Supabase Clientのシングルトンパターン実装
- 不要な依存関係の削除 (SQLAlchemy, psycopg2-binary, alembic)

## 動作確認
- ✅ Docker環境での起動確認
- ✅ ユーザー登録・ログイン機能の動作確認
- ✅ ダッシュボードへのリダイレクト確認

## テスト環境
- バックエンド: http://localhost:8000
- フロントエンド: http://localhost:3000
- Supabaseプロジェクト: nissei-app (wwyrthkizkcgndyorcww)

🤖 Generated with [Claude Code](https://claude.com/claude-code)