### PR TITLE
feat: Codex自動レビューワークフローを追加

### DIFF
--- a/.github/workflows/codex-autocomment.yml
+++ b/.github/workflows/codex-autocomment.yml
@@ -1,0 +1,25 @@
+name: Auto-trigger Codex via comment
+
+on:
+  pull_request:
+    # PR作成・更新・再オープン・下書き→準備完了 で実行
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  issues: write          # ← コメント投稿に必要
+  pull-requests: write   # ← 一部APIで必要になる場合に備え保険
+
+jobs:
+  comment-codex:
+    if: ${{ !github.event.pull_request.draft }}  # draftは除外（ready_for_reviewで拾う）
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post "@codex review" comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo
+            const issue_number = context.payload.pull_request.number
+            const body = '@codex review'
+            await github.rest.issues.createComment({ owner, repo, issue_number, body })


### PR DESCRIPTION
## 概要

PR作成・更新時に自動で `@codex review` コメントを投稿するGitHub Actionsワークフローを追加しました。

## 追加内容

### ✅ Codex自動レビューワークフロー
- ファイル: `.github/workflows/codex-autocomment.yml`
- PR作成・更新時に自動で `@codex review` コメント投稿
- Draft PRは除外し、Ready for Review時に実行

### トリガー条件
- `opened`: PR作成時
- `synchronize`: PR更新時（新しいコミットpush時）
- `reopened`: PR再オープン時
- `ready_for_review`: Draft→Ready変更時

### セキュリティ設定
- 最小権限の原則に従い以下のみ付与:
  - `contents: read` - 読み取り専用
  - `issues: write` - コメント投稿用
  - `pull-requests: write` - PR操作用

## 動作確認

このPRがマージされた後、次回のPR作成時に自動で `@codex review` コメントが投稿されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)