### PR TITLE
docs: usersテーブルにis_adminカラムを追加

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -13,7 +13,9 @@ users
 ├── id (PK)
 ├── email
 ├── username
-└── password_hash
+├── password_hash
+├── is_active
+└── is_admin
 
 projects
 ├── id (PK)
@@ -79,6 +81,7 @@ work_types (マスタ)
 | username | VARCHAR(100) | NO | - | ユーザー名 |
 | password_hash | VARCHAR(255) | NO | - | ハッシュ化パスワード |
 | is_active | BOOLEAN | NO | true | アクティブフラグ |
+| is_admin | BOOLEAN | NO | false | 管理者フラグ |
 | created_at | TIMESTAMP | NO | CURRENT_TIMESTAMP | 作成日時 |
 | updated_at | TIMESTAMP | NO | CURRENT_TIMESTAMP | 更新日時 |
 


### PR DESCRIPTION
## 概要

PR #25で追加された管理者API機能に対応し、DATABASE.mdにusersテーブルの`is_admin`カラムを追加しました。

## 変更内容

- **ER図**: usersテーブルに`is_active`と`is_admin`を追加
- **テーブル定義**: `is_admin` (BOOLEAN, default: false, 管理者フラグ) を追加

## 関連PR

- PR #25: ai-rules/ドキュメント構造を整理・統合（管理者API機能を含む）

## テスト手順

1. [docs/DATABASE.md](../docs/DATABASE.md) を確認
2. usersテーブルのER図と定義に`is_admin`が含まれていることを確認
3. backend/app/models/user.pyの実装と一致していることを確認