### PR TITLE
docs: ai-rules/とCLAUDE.mdの用語統一と整合性の確保

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@
 1. 変更をコミット（[コミット規約](./ai-rules/COMMIT_GUIDELINES.md)に従う）
 2. リモートブランチにpush
 3. PRを作成（[PR規約](./ai-rules/PR_GUIDELINES.md)に従う）
-4. **必須**: code-reviewer サブエージェントでレビューを依頼（[PRマージプロセス](./ai-rules/PR_MERGE_PROCESS.md)参照）
+4. **必須**: Task tool (general-purpose subagent)でレビューを依頼（[PRマージプロセス](./ai-rules/PR_MERGE_PROCESS.md)参照）
 5. レビュー完了後にmainへマージ
 6. **必須**: マージ後に docs/ の更新が必要か確認・更新
 
@@ -81,12 +81,12 @@ User ID: 00000000-0000-4000-8000-000000000000
 詳細は [ai-rules/PR_MERGE_PROCESS.md](./ai-rules/PR_MERGE_PROCESS.md) を参照。
 
 ### レビュー方法（必須）
-1. PR作成直後に **code-reviewer サブエージェント**でレビュー依頼（自動または明示的）
+1. PR作成直後に **Task tool (general-purpose subagent)**でレビュー依頼（自動または明示的）
 2. レビュー結果を評価（Critical/Major/Minor）
 3. 指摘事項を確認し、必要に応じて修正・Issue化
 4. レビュー承認後にmainへマージ
 
-**サブエージェント設定**: `.claude/agents/code-reviewer.md` に定義
+**サブエージェント設定**: `Task tool` に定義
 
 参考: [CODE_REVIEW.md](./ai-rules/CODE_REVIEW.md)（レビュー観点チェックリスト）
 
@@ -103,7 +103,7 @@ User ID: 00000000-0000-4000-8000-000000000000
 - **supabase**: DB/認証/ストレージ連携
 
 ### カスタムサブエージェント
-- **code-reviewer** (`.claude/agents/code-reviewer.md`): PRレビュー専門エージェント
+- **code-reviewer** (`Task tool`): PRレビュー専門エージェント
 
 ## Context7利用
 

--- a/ai-rules/PR_MERGE_PROCESS.md
+++ b/ai-rules/PR_MERGE_PROCESS.md
@@ -23,38 +23,33 @@
 
 **参考**: [PR_GUIDELINES.md](./PR_GUIDELINES.md)
 
-### 2. Claude Code サブエージェント (code-reviewer) によるレビュー
+### 2. Task tool (general-purpose subagent) によるレビュー
 
-PRが作成されたら、**code-reviewer サブエージェント**を使用してレビューを依頼します。
+PRが作成されたら、**Task tool (general-purpose subagent)** を使用してレビューを依頼します。
 
-#### サブエージェントについて
+#### Task toolについて
 
-`.claude/agents/code-reviewer.md` に定義された専門的なコードレビューエージェントです。
-- 独立したコンテキストで動作
-- GitHub API ツールに特化したアクセス
+Claude Codeの標準機能です。
+- PRレビューを含む多様なタスクに対応
+- GitHub API連携による差分解析
 - 一貫したレビュー基準とフォーマット
 
 #### レビュー依頼方法
 
-以下のいずれかの方法でレビューを依頼します：
+以下のコマンドでレビューを依頼します：
 
-**方法1: 自動呼び出し（推奨）**
-
-PRを作成すると、Claude Codeが自動的にcode-reviewerサブエージェントを呼び出します。
-
-**方法2: 明示的な呼び出し**
-
-```
-> code-reviewerサブエージェントを使用してPR #[番号]をレビューしてください
+```typescript
+Task tool:
+- subagent_type: "general-purpose"
+- description: "Review PR #[番号]"
+- prompt: "PRをレビューして、Critical/Major/Minor問題を報告してください"
 ```
 
-または
+または、ユーザーが以下のように依頼することもできます：
 
 ```
 > PR #[番号]をレビューしてください
 ```
-
-（Claude Codeが適切なサブエージェントを選択します）
 
 #### レビュー観点
 
@@ -73,7 +68,7 @@ PRを作成すると、Claude Codeが自動的にcode-reviewerサブエージェ
 
 ### 3. レビュー結果の評価
 
-Claude Code サブエージェント (Task tool) からのレビュー結果を以下の基準で評価します：
+Task tool (general-purpose subagent) からのレビュー結果を以下の基準で評価します：
 
 #### マージ可
 
@@ -113,7 +108,7 @@ Claude Code サブエージェント (Task tool) からのレビュー結果を�
    ```
 
 3. **再レビュー依頼**
-   - PR更新後、再度Claude Code サブエージェント (Task tool) にレビュー依頼
+   - PR更新後、再度Task tool (general-purpose subagent) にレビュー依頼
    - すべてのCritical/Major問題が解決されるまで繰り返す
 
 ### 5. GitHub Issue作成（必要に応じて）
@@ -161,7 +156,7 @@ mcp__github__merge_pull_request
 - 変更点2
 - 変更点3
 
-レビュー実施済み（Claude Code サブエージェント）: <マージ判定>
+レビュー実施済み（Task tool）: <マージ判定>
 - セキュリティ: <評価>
 - 今後の改善点: Issue #XX, #YY で管理予定
 "
@@ -199,7 +194,7 @@ git checkout -b docs-update-<内容>
 
 # 3. ドキュメントを更新
 # 4. コミット・push・PR作成
-# 5. Claude Code サブエージェント (Task tool) レビュー → マージ（通常フロー）
+# 5. Task tool (general-purpose subagent) レビュー → マージ（通常フロー）
 ```
 
 ### 8. レビュー履歴の記録
@@ -212,7 +207,7 @@ git checkout -b docs-update-<内容>
 ## PR #XX: [タイトル]
 
 **マージ日時**: 2025-10-01
-**レビュアー**: Claude Code サブエージェント (Task tool)
+**レビュアー**: Task tool (general-purpose subagent)
 **判定**: [マージ可/マージ不可]
 
 ### 変更内容
@@ -261,7 +256,7 @@ git checkout -b docs-update-<内容>
 ### PR #22: 管理者パネルと工数入力の改善
 
 1. **PR作成**: feat-admin-panel-and-worklog-improvements → main
-2. **Claude Code サブエージェント (Task tool) レビュー**: マージ可（条件付き）
+2. **Task tool (general-purpose subagent) レビュー**: マージ可（条件付き）
    - Major問題3件（JWT改ざん対策、URL推測、エラーハンドリング）
    - Minor問題5件
 3. **評価**: バックエンドで適切に保護されており、実害は限定的と判断
@@ -272,7 +267,7 @@ git checkout -b docs-update-<内容>
 ### PR #21, #20: マージ不可（Critical問題あり）
 
 1. **PR作成**: 工数入力機能の改修
-2. **Claude Code サブエージェント (Task tool) レビュー**: マージ不可
+2. **Task tool (general-purpose subagent) レビュー**: マージ不可
    - **Critical問題**: データベーススキーマ不一致によるデータ損失
 3. **Issue作成**: Issue #23, #24 を作成
 4. **対応**: Issue修正後に再レビュー → マージ

--- a/ai-rules/README.md
+++ b/ai-rules/README.md
@@ -15,7 +15,7 @@
    - ブランチ作成、コミット、PR作成、レビュー、マージの全工程
 
 2. **[PR_MERGE_PROCESS.md](./PR_MERGE_PROCESS.md)** - PRマージプロセス
-   - Claude Code サブエージェント (Task tool) によるレビュー方法
+   - Task tool (general-purpose subagent) によるレビュー方法
    - レビュー結果の評価基準
    - Issue作成とマージ実行の詳細手順
 
@@ -88,13 +88,13 @@
 4. [TESTING.md](./TESTING.md) に従ってE2Eテストを実施
 5. [COMMIT_GUIDELINES.md](./COMMIT_GUIDELINES.md) に従ってコミット
 6. [PR_GUIDELINES.md](./PR_GUIDELINES.md) に従ってPR作成
-7. [PR_MERGE_PROCESS.md](./PR_MERGE_PROCESS.md) に従ってClaude Code サブエージェント (Task tool) レビューを依頼
+7. [PR_MERGE_PROCESS.md](./PR_MERGE_PROCESS.md) に従ってTask tool (general-purpose subagent) レビューを依頼
 8. レビュー承認後、mainブランチへマージ
 
 ### コードレビューを実施する場合
 
 1. [CODE_REVIEW.md](./CODE_REVIEW.md) でチェック項目を確認
-2. [PR_MERGE_PROCESS.md](./PR_MERGE_PROCESS.md) に従ってClaude Code サブエージェント (Task tool) にレビュー依頼
+2. [PR_MERGE_PROCESS.md](./PR_MERGE_PROCESS.md) に従ってTask tool (general-purpose subagent) にレビュー依頼
 3. レビュー結果を評価（Critical/Major/Minor）
 4. 必要に応じて [ISSUE_GUIDELINES.md](./ISSUE_GUIDELINES.md) に従ってIssue作成
 
@@ -103,7 +103,7 @@
 1. [ISSUE_GUIDELINES.md](./ISSUE_GUIDELINES.md) に従ってIssue作成
 2. [WORKFLOW.md](./WORKFLOW.md) に従って修正用ブランチを作成
 3. 修正後、E2Eテストで動作確認
-4. PR作成してClaude Code サブエージェント (Task tool) レビュー
+4. PR作成してTask tool (general-purpose subagent) レビュー
 
 ---
 
@@ -135,7 +135,7 @@ WORKFLOW.md (全体の流れ)
 
 - **mainブランチへの直接作業は絶対禁止**
 - **コミット前に必ず動作確認とE2Eテストを実施**
-- **PR作成直後に必ずClaude Code サブエージェント (Task tool) レビューを依頼**
+- **PR作成直後に必ずTask tool (general-purpose subagent) レビューを依頼**
 - **Critical問題が存在する場合は絶対にマージしない**
 - **機密情報（APIキー、パスワード等）はコミットしない**
 
@@ -144,7 +144,7 @@ WORKFLOW.md (全体の流れ)
 ## 📝 更新履歴
 
 - **2025-10-01**: 全ドキュメントを整理・統合
-  - Claude Code サブエージェント (Task tool) による実際のレビューフローに合わせて更新
+  - Task tool (general-purpose subagent) による実際のレビューフローに合わせて更新
   - 重複を削除し、相互参照を明確化
   - ISSUE_GUIDELINES.md を新規作成
   - README.md（このファイル）を新規作成

--- a/ai-rules/WORKFLOW.md
+++ b/ai-rules/WORKFLOW.md
@@ -104,11 +104,11 @@ Closes #XX
 
 **PRテンプレートの詳細**: [PR_GUIDELINES.md](./PR_GUIDELINES.md)
 
-### 4. Claude Code サブエージェント (Task tool) レビュー依頼（必須）
+### 4. Task tool (general-purpose subagent) レビュー依頼（必須）
 
 ⚠️ **重要**: PR作成直後に必ず実施
 
-Task toolを使用してレビュー依頼を行います。
+Task tool (general-purpose subagent) を使用してレビュー依頼を行います。
 
 **レビュープロセスの詳細**: [PR_MERGE_PROCESS.md](./PR_MERGE_PROCESS.md)
 
@@ -136,11 +136,11 @@ Task toolを使用してレビュー依頼を行います。
    ```
 
 3. **再レビュー依頼**
-   - PR更新後、再度Claude Code サブエージェント (Task tool) にレビュー依頼
+   - PR更新後、再度Task tool (general-purpose subagent) にレビュー依頼
    - 修正内容をPRコメントで報告（推奨）
 
 4. **修正完了まで繰り返し**
-   - すべてのCritical/Major問題が解決されるまで「修正 → push → Claude Code サブエージェント (Task tool) レビュー」を繰り返す
+   - すべてのCritical/Major問題が解決されるまで「修正 → push → Task tool (general-purpose subagent) レビュー」を繰り返す
 
 ### 6. マージ（レビュー承認後）
 
@@ -214,7 +214,7 @@ git checkout -b docs-update-<内容>
 
 # 3. ドキュメントを更新
 # 4. コミット・push・PR作成
-# 5. Claude Code サブエージェント (Task tool) レビュー → マージ（通常フロー）
+# 5. Task tool (general-purpose subagent) レビュー → マージ（通常フロー）
 ```
 
 ---
@@ -236,7 +236,7 @@ git checkout -b docs-update-<内容>
     ↓
 [PR作成] (PR_GUIDELINES.md準拠)
     ↓
-[Claude Code サブエージェント (Task tool) レビュー依頼] ← 必須
+[Task tool (general-purpose subagent) レビュー依頼] ← 必須
     ↓
 [レビュー結果確認]
     ├─[マージ可] → [マージ] → [docs/ 更新確認] ← 必須
@@ -269,7 +269,7 @@ git checkout -b docs-update-<内容>
 
 - ⚠️ **mainブランチへの直接作業は絶対禁止**
 - ⚠️ **コミット前に必ず動作確認とE2Eテストを実施**
-- ⚠️ **PR作成直後に必ずClaude Code サブエージェント (Task tool) レビューを依頼**
+- ⚠️ **PR作成直後に必ずTask tool (general-purpose subagent) レビューを依頼**
 - ⚠️ **Critical問題が存在する場合は絶対にマージしない**
 - ⚠️ **PR作成→レビュー→マージまでを1セットの作業として完了させる**（PRを溜めない）
 - ⚠️ **マージ後は必ず docs/ の更新が必要か確認する**


### PR DESCRIPTION
このPRは誤った方向の変更でした。

**問題点**:
- `.claude/agents/code-reviewer.md` サブエージェントは実在するファイルであり、使用すべきもの
- "Task tool" への置き換えは誤り
- 正しくは "code-reviewer サブエージェント" を使用するべき

新しいアプローチで再度ドキュメント整理を行います。