### PR TITLE
docs: code-reviewerサブエージェントを正しく参照するよう修正

### DIFF
--- a/ai-rules/CODE_REVIEW.md
+++ b/ai-rules/CODE_REVIEW.md
@@ -12,7 +12,7 @@
 ⚠️ **PR作成直後に必ず実施**
 
 ### レビュー方法
-詳細は [PR_MERGE_PROCESS.md](./PR_MERGE_PROCESS.md) の「Claude Code サブエージェント (Task tool) によるレビュー」セクションを参照してください。
+詳細は [PR_MERGE_PROCESS.md](./PR_MERGE_PROCESS.md) の「code-reviewer サブエージェント によるレビュー」セクションを参照してください。
 
 ---
 
@@ -109,7 +109,7 @@ PR作成前に自分でチェック：
 ⚠️ **重要**: PRを更新（コミット・push）するたびに、必ず以下を実施：
 
 ### 1. 再レビュー依頼
-Claude Code サブエージェント (Task tool) で再度レビュー依頼を実施
+code-reviewer サブエージェント で再度レビュー依頼を実施
 
 ### 2. 修正内容の確認
 ```markdown
@@ -123,11 +123,11 @@ Claude Code サブエージェント (Task tool) で再度レビュー依頼を�
 ```
 
 ### 3. レビュー結果を確認
-- Claude Code サブエージェント (Task tool) が最新コミットを確認
+- code-reviewer サブエージェント が最新コミットを確認
 - 新たな指摘があれば再度修正
 
 ### 4. すべての指摘が解決されるまで繰り返し
-- 「修正 → push → Claude Code サブエージェント (Task tool) レビュー」を繰り返す
+- 「修正 → push → code-reviewer サブエージェント レビュー」を繰り返す
 - すべての指摘が解決されたらマージ可能
 
 ---
@@ -155,7 +155,7 @@ Claude Code サブエージェント (Task tool) で再度レビュー依頼を�
 ### 修正が必要な場合
 1. 指摘事項を修正
 2. コミット・プッシュ
-3. **必ず** Claude Code サブエージェント (Task tool) で再レビュー依頼
+3. **必ず** code-reviewer サブエージェント で再レビュー依頼
 
 ### 議論が必要な場合
 1. PRコメントで議論

--- a/ai-rules/PR_MERGE_PROCESS.md
+++ b/ai-rules/PR_MERGE_PROCESS.md
@@ -3,7 +3,7 @@
 このドキュメントでは、PRのレビューからマージまでの標準プロセスを定義します。
 
 **最終更新**: 2025-10-01
-**更新理由**: Claude Code サブエージェント (Task tool) による実際のレビューフローに合わせて全面改訂
+**更新理由**: code-reviewer サブエージェント による実際のレビューフローに合わせて全面改訂
 
 ---
 
@@ -23,7 +23,7 @@
 
 **参考**: [PR_GUIDELINES.md](./PR_GUIDELINES.md)
 
-### 2. Claude Code サブエージェント (code-reviewer) によるレビュー
+### 2. code-reviewer サブエージェント によるレビュー
 
 PRが作成されたら、**code-reviewer サブエージェント**を使用してレビューを依頼します。
 
@@ -73,7 +73,7 @@ PRを作成すると、Claude Codeが自動的にcode-reviewerサブエージェ
 
 ### 3. レビュー結果の評価
 
-Claude Code サブエージェント (Task tool) からのレビュー結果を以下の基準で評価します：
+code-reviewer サブエージェント からのレビュー結果を以下の基準で評価します：
 
 #### マージ可
 
@@ -113,7 +113,7 @@ Claude Code サブエージェント (Task tool) からのレビュー結果を�
    ```
 
 3. **再レビュー依頼**
-   - PR更新後、再度Claude Code サブエージェント (Task tool) にレビュー依頼
+   - PR更新後、再度code-reviewer サブエージェント にレビュー依頼
    - すべてのCritical/Major問題が解決されるまで繰り返す
 
 ### 5. GitHub Issue作成（必要に応じて）
@@ -161,7 +161,7 @@ mcp__github__merge_pull_request
 - 変更点2
 - 変更点3
 
-レビュー実施済み（Claude Code サブエージェント）: <マージ判定>
+レビュー実施済み（code-reviewer サブエージェント）: <マージ判定>
 - セキュリティ: <評価>
 - 今後の改善点: Issue #XX, #YY で管理予定
 "
@@ -199,7 +199,7 @@ git checkout -b docs-update-<内容>
 
 # 3. ドキュメントを更新
 # 4. コミット・push・PR作成
-# 5. Claude Code サブエージェント (Task tool) レビュー → マージ（通常フロー）
+# 5. code-reviewer サブエージェント レビュー → マージ（通常フロー）
 ```
 
 ### 8. レビュー履歴の記録
@@ -212,7 +212,7 @@ git checkout -b docs-update-<内容>
 ## PR #XX: [タイトル]
 
 **マージ日時**: 2025-10-01
-**レビュアー**: Claude Code サブエージェント (Task tool)
+**レビュアー**: code-reviewer サブエージェント
 **判定**: [マージ可/マージ不可]
 
 ### 変更内容
@@ -261,7 +261,7 @@ git checkout -b docs-update-<内容>
 ### PR #22: 管理者パネルと工数入力の改善
 
 1. **PR作成**: feat-admin-panel-and-worklog-improvements → main
-2. **Claude Code サブエージェント (Task tool) レビュー**: マージ可（条件付き）
+2. **code-reviewer サブエージェント レビュー**: マージ可（条件付き）
    - Major問題3件（JWT改ざん対策、URL推測、エラーハンドリング）
    - Minor問題5件
 3. **評価**: バックエンドで適切に保護されており、実害は限定的と判断
@@ -272,7 +272,7 @@ git checkout -b docs-update-<内容>
 ### PR #21, #20: マージ不可（Critical問題あり）
 
 1. **PR作成**: 工数入力機能の改修
-2. **Claude Code サブエージェント (Task tool) レビュー**: マージ不可
+2. **code-reviewer サブエージェント レビュー**: マージ不可
    - **Critical問題**: データベーススキーマ不一致によるデータ損失
 3. **Issue作成**: Issue #23, #24 を作成
 4. **対応**: Issue修正後に再レビュー → マージ

--- a/ai-rules/README.md
+++ b/ai-rules/README.md
@@ -15,7 +15,7 @@
    - ブランチ作成、コミット、PR作成、レビュー、マージの全工程
 
 2. **[PR_MERGE_PROCESS.md](./PR_MERGE_PROCESS.md)** - PRマージプロセス
-   - Claude Code サブエージェント (Task tool) によるレビュー方法
+   - code-reviewer サブエージェント によるレビュー方法
    - レビュー結果の評価基準
    - Issue作成とマージ実行の詳細手順
 
@@ -88,13 +88,13 @@
 4. [TESTING.md](./TESTING.md) に従ってE2Eテストを実施
 5. [COMMIT_GUIDELINES.md](./COMMIT_GUIDELINES.md) に従ってコミット
 6. [PR_GUIDELINES.md](./PR_GUIDELINES.md) に従ってPR作成
-7. [PR_MERGE_PROCESS.md](./PR_MERGE_PROCESS.md) に従ってClaude Code サブエージェント (Task tool) レビューを依頼
+7. [PR_MERGE_PROCESS.md](./PR_MERGE_PROCESS.md) に従ってcode-reviewer サブエージェント レビューを依頼
 8. レビュー承認後、mainブランチへマージ
 
 ### コードレビューを実施する場合
 
 1. [CODE_REVIEW.md](./CODE_REVIEW.md) でチェック項目を確認
-2. [PR_MERGE_PROCESS.md](./PR_MERGE_PROCESS.md) に従ってClaude Code サブエージェント (Task tool) にレビュー依頼
+2. [PR_MERGE_PROCESS.md](./PR_MERGE_PROCESS.md) に従ってcode-reviewer サブエージェント にレビュー依頼
 3. レビュー結果を評価（Critical/Major/Minor）
 4. 必要に応じて [ISSUE_GUIDELINES.md](./ISSUE_GUIDELINES.md) に従ってIssue作成
 
@@ -103,7 +103,7 @@
 1. [ISSUE_GUIDELINES.md](./ISSUE_GUIDELINES.md) に従ってIssue作成
 2. [WORKFLOW.md](./WORKFLOW.md) に従って修正用ブランチを作成
 3. 修正後、E2Eテストで動作確認
-4. PR作成してClaude Code サブエージェント (Task tool) レビュー
+4. PR作成してcode-reviewer サブエージェント レビュー
 
 ---
 
@@ -135,7 +135,7 @@ WORKFLOW.md (全体の流れ)
 
 - **mainブランチへの直接作業は絶対禁止**
 - **コミット前に必ず動作確認とE2Eテストを実施**
-- **PR作成直後に必ずClaude Code サブエージェント (Task tool) レビューを依頼**
+- **PR作成直後に必ずcode-reviewer サブエージェント レビューを依頼**
 - **Critical問題が存在する場合は絶対にマージしない**
 - **機密情報（APIキー、パスワード等）はコミットしない**
 
@@ -144,7 +144,7 @@ WORKFLOW.md (全体の流れ)
 ## 📝 更新履歴
 
 - **2025-10-01**: 全ドキュメントを整理・統合
-  - Claude Code サブエージェント (Task tool) による実際のレビューフローに合わせて更新
+  - code-reviewer サブエージェント による実際のレビューフローに合わせて更新
   - 重複を削除し、相互参照を明確化
   - ISSUE_GUIDELINES.md を新規作成
   - README.md（このファイル）を新規作成

--- a/ai-rules/WORKFLOW.md
+++ b/ai-rules/WORKFLOW.md
@@ -104,7 +104,7 @@ Closes #XX
 
 **PRテンプレートの詳細**: [PR_GUIDELINES.md](./PR_GUIDELINES.md)
 
-### 4. Claude Code サブエージェント (Task tool) レビュー依頼（必須）
+### 4. code-reviewer サブエージェント レビュー依頼（必須）
 
 ⚠️ **重要**: PR作成直後に必ず実施
 
@@ -136,11 +136,11 @@ Task toolを使用してレビュー依頼を行います。
    ```
 
 3. **再レビュー依頼**
-   - PR更新後、再度Claude Code サブエージェント (Task tool) にレビュー依頼
+   - PR更新後、再度code-reviewer サブエージェント にレビュー依頼
    - 修正内容をPRコメントで報告（推奨）
 
 4. **修正完了まで繰り返し**
-   - すべてのCritical/Major問題が解決されるまで「修正 → push → Claude Code サブエージェント (Task tool) レビュー」を繰り返す
+   - すべてのCritical/Major問題が解決されるまで「修正 → push → code-reviewer サブエージェント レビュー」を繰り返す
 
 ### 6. マージ（レビュー承認後）
 
@@ -214,7 +214,7 @@ git checkout -b docs-update-<内容>
 
 # 3. ドキュメントを更新
 # 4. コミット・push・PR作成
-# 5. Claude Code サブエージェント (Task tool) レビュー → マージ（通常フロー）
+# 5. code-reviewer サブエージェント レビュー → マージ（通常フロー）
 ```
 
 ---
@@ -236,7 +236,7 @@ git checkout -b docs-update-<内容>
     ↓
 [PR作成] (PR_GUIDELINES.md準拠)
     ↓
-[Claude Code サブエージェント (Task tool) レビュー依頼] ← 必須
+[code-reviewer サブエージェント レビュー依頼] ← 必須
     ↓
 [レビュー結果確認]
     ├─[マージ可] → [マージ] → [docs/ 更新確認] ← 必須
@@ -269,7 +269,7 @@ git checkout -b docs-update-<内容>
 
 - ⚠️ **mainブランチへの直接作業は絶対禁止**
 - ⚠️ **コミット前に必ず動作確認とE2Eテストを実施**
-- ⚠️ **PR作成直後に必ずClaude Code サブエージェント (Task tool) レビューを依頼**
+- ⚠️ **PR作成直後に必ずcode-reviewer サブエージェント レビューを依頼**
 - ⚠️ **Critical問題が存在する場合は絶対にマージしない**
 - ⚠️ **PR作成→レビュー→マージまでを1セットの作業として完了させる**（PRを溜めない）
 - ⚠️ **マージ後は必ず docs/ の更新が必要か確認する**


### PR DESCRIPTION
## 概要

ai-rulesドキュメント内で、実在する `code-reviewer` サブエージェントを正しく参照するように修正しました。

## 背景

- `.claude/agents/code-reviewer.md` は実在する専用のPRレビューサブエージェント
- ドキュメント内で「Claude Code サブエージェント (Task tool)」という不正確な表現が使用されていた
- 実際に使用すべきは「code-reviewer サブエージェント」

## 変更内容

### 修正ファイル

- **ai-rules/README.md**: レビュー方法の説明を修正
- **ai-rules/WORKFLOW.md**: ワークフロー内のレビュー依頼手順を修正
- **ai-rules/PR_MERGE_PROCESS.md**: レビュープロセスの説明を修正
- **ai-rules/CODE_REVIEW.md**: レビュー実施方法を修正

### 変更内容

すべてのドキュメント内で：
- ❌ 「Claude Code サブエージェント (Task tool)」
- ✅ 「code-reviewer サブエージェント」

に統一しました。

## テスト手順

1. ドキュメントの整合性を確認
   ```bash
   grep -r "code-reviewer" ai-rules/
   grep -r "Task tool" ai-rules/ # 不正確な表現が残っていないか確認
   ```

2. `.claude/agents/code-reviewer.md` が存在することを確認
   ```bash
   ls -la .claude/agents/code-reviewer.md
   ```

## 関連Issue

Closes #なし（ドキュメント修正のみ）

## チェックリスト

- [x] ドキュメントの整合性を確認
- [x] CLAUDE.mdが既に正しい参照を使用していることを確認
- [x] すべてのai-rulesファイルで用語を統一
- [x] `.claude/agents/code-reviewer.md` が実在することを確認