### PR TITLE
docs: 工数入力APIにstart_time/end_timeフィールドを追加

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -227,6 +227,8 @@ Content-Type: application/json
       "user_id": "uuid",
       "work_date": "2025-01-01",
       "duration_minutes": 480,
+      "start_time": "09:00:00",
+      "end_time": "17:00:00",
       "work_content": "作業内容",
       "created_at": "2025-01-01T00:00:00Z",
       "updated_at": "2025-01-01T00:00:00Z"
@@ -247,13 +249,15 @@ Content-Type: application/json
   "project_id": "uuid",
   "work_date": "2025-01-01",
   "duration_minutes": 480,
+  "start_time": "09:00:00",
+  "end_time": "17:00:00",
   "work_content": "作業内容の説明"
 }
 ```
 
 **注意**:
 - `duration_minutes` は15分刻みでの入力を推奨（15, 30, 45, 60, ...）
-- 開始時刻・終了時刻は不要（duration_minutesのみで記録）
+- `start_time`, `end_time`, `work_content` はオプション（duration_minutesは必須）
 
 **レスポンス (201 Created)**
 ```json
@@ -263,8 +267,11 @@ Content-Type: application/json
   "user_id": "uuid",
   "work_date": "2025-01-01",
   "duration_minutes": 480,
+  "start_time": "09:00:00",
+  "end_time": "17:00:00",
   "work_content": "作業内容の説明",
-  "created_at": "2025-01-01T00:00:00Z"
+  "created_at": "2025-01-01T00:00:00Z",
+  "updated_at": "2025-01-01T00:00:00Z"
 }
 ```
 
@@ -279,6 +286,8 @@ Content-Type: application/json
   "user_id": "uuid",
   "work_date": "2025-01-01",
   "duration_minutes": 480,
+  "start_time": "09:00:00",
+  "end_time": "17:00:00",
   "work_content": "作業内容",
   "created_at": "2025-01-01T00:00:00Z",
   "updated_at": "2025-01-01T00:00:00Z"
@@ -294,6 +303,8 @@ Content-Type: application/json
   "project_id": "uuid",
   "work_date": "2025-01-02",
   "duration_minutes": 240,
+  "start_time": "10:00:00",
+  "end_time": "14:00:00",
   "work_content": "更新後の作業内容"
 }
 ```
@@ -306,7 +317,10 @@ Content-Type: application/json
   "user_id": "uuid",
   "work_date": "2025-01-02",
   "duration_minutes": 240,
+  "start_time": "10:00:00",
+  "end_time": "14:00:00",
   "work_content": "更新後の作業内容",
+  "created_at": "2025-01-01T00:00:00Z",
   "updated_at": "2025-01-02T00:00:00Z"
 }
 ```


### PR DESCRIPTION
## 概要

PR #31（Issue #23データ損失問題の解決）のフォローアップとして、API仕様書を最新の実装に合わせて更新します。

## 変更内容

### docs/API.md の更新

#### 工数入力API（`/api/worklogs`）の更新
- **GET /api/worklogs**: レスポンス例に`start_time`, `end_time`を追加
- **POST /api/worklogs**: リクエスト/レスポンス例に`start_time`, `end_time`を追加
- **GET /api/worklogs/{id}**: レスポンス例に`start_time`, `end_time`を追加
- **PUT /api/worklogs/{id}**: リクエスト/レスポンス例に`start_time`, `end_time`を追加

#### 注意事項の修正
- **旧**: 「開始時刻・終了時刻は不要（duration_minutesのみで記録）」
- **新**: 「start_time, end_time, work_contentはオプション（duration_minutesは必須）」

## 背景

PR #31で以下の変更を実施しましたが、API仕様書が更新されていませんでした：

1. データベースの`work_logs`テーブルに`start_time`, `end_time`, `work_content`カラムを追加
2. バックエンドAPIは既にこれらのフィールドをサポート済み
3. フロントエンドも既に対応済み

このPRでドキュメントを実装に合わせて更新します。

## 関連Issue/PR

- Closes なし（ドキュメント更新のみ）
- Related: PR #31（Issue #23データ損失問題の解決）

## テスト

- [ ] ドキュメントの記述が実装と一致していることを確認
- [ ] マークダウン形式が正しいことを確認

## チェックリスト

- [x] コミットメッセージが[COMMIT_GUIDELINES.md](../ai-rules/COMMIT_GUIDELINES.md)に準拠
- [x] 変更内容が明確に記述されている
- [x] 関連PRを明記

🤖 Generated with [Claude Code](https://claude.com/claude-code)