### PR TITLE
docs: usersテーブルのpasswordカラム名をhashed_passwordに統一

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -13,7 +13,7 @@ users
 ├── id (PK)
 ├── email
 ├── username
-├── password_hash
+├── hashed_password
 ├── is_active
 └── is_admin
 
@@ -84,7 +84,7 @@ work_types (マスタ)
 | id | UUID | NO | gen_random_uuid() | 主キー |
 | email | VARCHAR(255) | NO | - | メールアドレス（ユニーク） |
 | username | VARCHAR(100) | NO | - | ユーザー名 |
-| password_hash | VARCHAR(255) | NO | - | ハッシュ化パスワード |
+| hashed_password | VARCHAR(255) | NO | - | ハッシュ化パスワード |
 | is_active | BOOLEAN | NO | true | アクティブフラグ |
 | is_admin | BOOLEAN | NO | false | 管理者フラグ |
 | created_at | TIMESTAMP | NO | CURRENT_TIMESTAMP | 作成日時 |


### PR DESCRIPTION
## 概要

Issue #27の解決: docs/DATABASE.mdと実装（backend/app/models/user.py）のpasswordカラム名の不一致を修正します。

## 変更内容

### docs/DATABASE.md の修正

#### ER図（2箇所）
- 旧: `password_hash`
- 新: `hashed_password`

#### usersテーブル定義
| カラム名 | 修正前 | 修正後 |
|---------|--------|--------|
| パスワード | password_hash | hashed_password |

## 背景

### 現状の不一致
- **実装** (`backend/app/models/user.py`): `hashed_password` を使用
- **ドキュメント** (`docs/DATABASE.md`): `password_hash` と記載

### 問題点
開発者がドキュメントと実装のどちらを信頼すべきか混乱する可能性があり、一貫性の観点から修正が必要でした。

### 選択した解決策
**選択肢A: ドキュメントを修正（実装）**
- 実装変更不要、リスクなし
- マイグレーション不要
- 既存データへの影響なし

選択肢B（実装を修正）は、マイグレーションと既存データへの影響リスクがあるため採用しませんでした。

## 関連Issue

Closes #27

## テスト

- [x] ドキュメントの記述が実装と一致していることを確認
- [x] 他のpassword関連の記述がないことを確認（grep実施済み）

## チェックリスト

- [x] コミットメッセージが[COMMIT_GUIDELINES.md](../ai-rules/COMMIT_GUIDELINES.md)に準拠
- [x] 変更内容が明確に記述されている
- [x] 関連Issueを明記

🤖 Generated with [Claude Code](https://claude.com/claude-code)