### PR TITLE
feat: 請求書生成機能を実装

### DIFF
--- a/backend/app/api/invoices.py
+++ b/backend/app/api/invoices.py
@@ -1,5 +1,340 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi.responses import StreamingResponse
+from supabase import Client
+from typing import Optional, Dict, Any, List
+from uuid import UUID
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+import io
+import csv
+
+from app.core.database import get_db
+from app.api.auth import get_current_user, require_admin
+from app.schemas.invoice import (
+    InvoiceCreate,
+    InvoiceUpdate,
+    InvoiceResponse,
+    InvoicePreviewResponse,
+    InvoicePreviewItem,
+)
 
 router = APIRouter()
 
-# 請求APIエンドポイント（後で実装）
+
+@router.get("/preview", response_model=InvoicePreviewResponse)
+def preview_invoice(
+    month: str = Query(..., description="YYYY-MM形式の月"),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: Client = Depends(get_db),
+):
+    """指定月の請求書プレビュー（work_logsから実工数を集計）"""
+    try:
+        # 月の開始日と終了日を計算
+        year, month_num = month.split('-')
+        start_date = f"{year}-{month_num}-01"
+
+        # 次月の1日を計算（終了日として使用）
+        if month_num == "12":
+            end_date = f"{int(year)+1}-01-01"
+        else:
+            end_date = f"{year}-{int(month_num)+1:02d}-01"
+
+        # worklogsから指定月の工数を取得（プロジェクト別に集計）
+        worklogs_response = db.table("worklogs").select("""
+            project_id,
+            duration_minutes
+        """).gte("work_date", start_date).lt("work_date", end_date).execute()
+
+        if not worklogs_response.data:
+            return InvoicePreviewResponse(
+                month=month,
+                total_hours=Decimal("0.00"),
+                items=[]
+            )
+
+        # プロジェクトIDごとに工数を集計
+        project_hours = {}
+        for log in worklogs_response.data:
+            project_id = log["project_id"]
+            minutes = log["duration_minutes"]
+            if project_id not in project_hours:
+                project_hours[project_id] = 0
+            project_hours[project_id] += minutes
+
+        # プロジェクト情報を取得
+        project_ids = list(project_hours.keys())
+        # 一時的な回避策：eq()を連鎖させる代わりに、各プロジェクトを個別に取得
+        projects_data = []
+        for project_id in project_ids:
+            response = db.table("projects").select("id, management_no, machine_no").eq("id", project_id).execute()
+            if response.data:
+                projects_data.extend(response.data)
+
+        if not projects_data:
+            return InvoicePreviewResponse(
+                month=month,
+                total_hours=Decimal("0.00"),
+                items=[]
+            )
+
+        # 請求書明細を作成
+        items = []
+        total_minutes = 0
+
+        for project in projects_data:
+            project_id = project["id"]
+            minutes = project_hours.get(project_id, 0)
+            hours = Decimal(minutes) / Decimal(60)
+
+            # 管理No.と号機No.を取得
+            management_no = project.get("management_no", "")
+            machine_no = project.get("machine_no", "")
+
+            items.append(InvoicePreviewItem(
+                management_no=management_no,
+                machine_no=machine_no,
+                actual_hours=hours.quantize(Decimal("0.01"))
+            ))
+            total_minutes += minutes
+
+        total_hours = (Decimal(total_minutes) / Decimal(60)).quantize(Decimal("0.01"))
+
+        # 管理Noでソート
+        items.sort(key=lambda x: x.management_no)
+
+        return InvoicePreviewResponse(
+            month=month,
+            total_hours=total_hours,
+            items=items
+        )
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"請求プレビューの取得に失敗しました: {str(e)}"
+        )
+
+
+@router.post("/close", response_model=InvoiceResponse)
+def close_invoice(
+    month: str = Query(..., description="YYYY-MM形式の月"),
+    current_user: Dict[str, Any] = Depends(require_admin),
+    db: Client = Depends(get_db),
+):
+    """請求書を確定（管理者のみ）"""
+    # プレビューデータを取得
+    preview = preview_invoice(month=month, current_user=current_user, db=db)
+
+    if not preview.items:
+        raise HTTPException(status_code=400, detail="請求対象の工数がありません")
+
+    # 請求書番号を生成（INV-YYYYMM-001形式）
+    year_month = month.replace('-', '')
+
+    # 同月の既存請求書を確認
+    existing_response = db.table("invoices").select("invoice_number").like(
+        "invoice_number", f"INV-{year_month}-%"
+    ).execute()
+
+    seq = 1
+    if existing_response.data:
+        # 最大番号を取得
+        max_num = 0
+        for inv in existing_response.data:
+            num_str = inv["invoice_number"].split('-')[-1]
+            try:
+                num = int(num_str)
+                if num > max_num:
+                    max_num = num
+            except ValueError:
+                pass
+        seq = max_num + 1
+
+    invoice_number = f"INV-{year_month}-{seq:03d}"
+
+    # 請求書を作成
+    invoice_data = {
+        "id": str(uuid.uuid4()),
+        "invoice_number": invoice_number,
+        "issue_date": str(date.today()),
+        "total_amount": float(preview.total_hours),
+        "status": "sent",
+    }
+
+    try:
+        invoice_response = db.table("invoices").insert(invoice_data).execute()
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"請求書の作成に失敗しました: {str(e)}"
+        )
+
+    if not invoice_response.data:
+        raise HTTPException(status_code=500, detail="請求書の作成に失敗しました")
+
+    invoice = invoice_response.data[0]
+    invoice_id = invoice["id"]
+
+    # 請求書明細を作成
+    items_data = []
+    for idx, item in enumerate(preview.items):
+        items_data.append({
+            "id": str(uuid.uuid4()),
+            "invoice_id": invoice_id,
+            "management_no": item.management_no,
+            "machine_no": item.machine_no,
+            "actual_hours": float(item.actual_hours),
+            "sort_order": idx,
+        })
+
+    try:
+        db.table("invoice_items").insert(items_data).execute()
+    except Exception as e:
+        # ロールバック（請求書を削除）
+        db.table("invoices").delete().eq("id", invoice_id).execute()
+        raise HTTPException(
+            status_code=500,
+            detail=f"請求書明細の作成に失敗しました: {str(e)}"
+        )
+
+    # 作成した請求書を取得（明細含む）
+    return get_invoice(invoice_id=UUID(invoice_id), current_user=current_user, db=db)
+
+
+@router.get("/export")
+def export_invoice_csv(
+    month: str = Query(..., description="YYYY-MM形式の月"),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: Client = Depends(get_db),
+):
+    """請求書CSVエクスポート"""
+    # プレビューデータを取得
+    preview = preview_invoice(month=month, current_user=current_user, db=db)
+
+    if not preview.items:
+        raise HTTPException(status_code=404, detail="請求対象の工数がありません")
+
+    # CSV作成
+    output = io.StringIO()
+    writer = csv.writer(output)
+
+    # ヘッダー
+    writer.writerow(['管理No', '委託業務内容', '実工数'])
+
+    # データ行
+    for item in preview.items:
+        writer.writerow([
+            item.management_no,
+            item.machine_no,
+            f"{item.actual_hours}H"
+        ])
+
+    # StreamingResponseで返す
+    output.seek(0)
+    return StreamingResponse(
+        iter([output.getvalue().encode('utf-8-sig')]),  # BOM付きUTF-8
+        media_type="text/csv",
+        headers={
+            "Content-Disposition": f"attachment; filename=invoice_{month}.csv"
+        }
+    )
+
+
+@router.get("/{invoice_id}", response_model=InvoiceResponse)
+def get_invoice(
+    invoice_id: UUID,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: Client = Depends(get_db),
+):
+    """請求書詳細を取得"""
+    # 請求書を取得
+    invoice_response = db.table("invoices").select("*").eq("id", str(invoice_id)).execute()
+
+    if not invoice_response.data:
+        raise HTTPException(status_code=404, detail="請求書が見つかりません")
+
+    invoice = invoice_response.data[0]
+
+    # 明細を取得
+    items_response = db.table("invoice_items").select("*").eq(
+        "invoice_id", str(invoice_id)
+    ).order("sort_order").execute()
+
+    invoice["items"] = items_response.data or []
+
+    return invoice
+
+
+@router.get("", response_model=List[InvoiceResponse])
+def list_invoices(
+    status: Optional[str] = Query(None, description="ステータスフィルタ"),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: Client = Depends(get_db),
+):
+    """請求書一覧を取得"""
+    query = db.table("invoices").select("*")
+
+    if status:
+        query = query.eq("status", status)
+
+    query = query.order("issue_date", desc=True)
+
+    invoices_response = query.execute()
+
+    if not invoices_response.data:
+        return []
+
+    # 各請求書の明細を取得
+    for invoice in invoices_response.data:
+        items_response = db.table("invoice_items").select("*").eq(
+            "invoice_id", invoice["id"]
+        ).order("sort_order").execute()
+        invoice["items"] = items_response.data or []
+
+    return invoices_response.data
+
+
+@router.patch("/{invoice_id}", response_model=InvoiceResponse)
+def update_invoice(
+    invoice_id: UUID,
+    invoice_data: InvoiceUpdate,
+    current_user: Dict[str, Any] = Depends(require_admin),
+    db: Client = Depends(get_db),
+):
+    """請求書を更新（管理者のみ、ステータス変更のみ）"""
+    # 既存の請求書を確認
+    existing = db.table("invoices").select("*").eq("id", str(invoice_id)).execute()
+
+    if not existing.data:
+        raise HTTPException(status_code=404, detail="請求書が見つかりません")
+
+    # 更新
+    update_dict = invoice_data.model_dump(exclude_unset=True, mode="json")
+    update_dict["updated_at"] = datetime.utcnow().isoformat()
+
+    updated_response = db.table("invoices").update(update_dict).eq("id", str(invoice_id)).execute()
+
+    if not updated_response.data:
+        raise HTTPException(status_code=500, detail="請求書の更新に失敗しました")
+
+    return get_invoice(invoice_id=invoice_id, current_user=current_user, db=db)
+
+
+@router.delete("/{invoice_id}")
+def delete_invoice(
+    invoice_id: UUID,
+    current_user: Dict[str, Any] = Depends(require_admin),
+    db: Client = Depends(get_db),
+):
+    """請求書を削除（管理者のみ、CASCADE）"""
+    # 既存の請求書を確認
+    existing = db.table("invoices").select("*").eq("id", str(invoice_id)).execute()
+
+    if not existing.data:
+        raise HTTPException(status_code=404, detail="請求書が見つかりません")
+
+    # 削除（invoice_itemsも自動削除される）
+    db.table("invoices").delete().eq("id", str(invoice_id)).execute()
+
+    return {"message": "請求書を削除しました"}

--- a/backend/app/models/invoice.py
+++ b/backend/app/models/invoice.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Integer, Date, DateTime, ForeignKey, Boolean
+from sqlalchemy import Column, String, Date, DateTime, ForeignKey, Integer, Numeric
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from datetime import datetime
@@ -10,14 +10,14 @@ class Invoice(Base):
     __tablename__ = "invoices"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    year_month = Column(String, nullable=False, index=True)  # YYYY-MM形式
-    executed_by = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
-    executed_at = Column(DateTime, nullable=False)
-    is_locked = Column(Boolean, default=False)  # 締め確定フラグ
-    created_at = Column(DateTime, default=datetime.utcnow)
+    invoice_number = Column(String(50), unique=True, nullable=False, index=True)
+    issue_date = Column(Date, nullable=False)
+    total_amount = Column(Numeric(12, 2), default=0.00, nullable=False)
+    status = Column(String(50), default='draft', nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
 
-    # Relationships
-    executor = relationship("User")
+    # リレーション
     items = relationship("InvoiceItem", back_populates="invoice", cascade="all, delete-orphan")
 
 
@@ -25,13 +25,12 @@ class InvoiceItem(Base):
     __tablename__ = "invoice_items"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    invoice_id = Column(UUID(as_uuid=True), ForeignKey("invoices.id"), nullable=False)
-    project_id = Column(UUID(as_uuid=True), ForeignKey("projects.id"), nullable=False)
-    management_no = Column(String, nullable=False)  # 管理No
-    commission_content = Column(String)  # 業務委託内容
-    actual_hours_decimal = Column(Integer)  # 実工数（時間、小数）※100倍して整数で保存
-    created_at = Column(DateTime, default=datetime.utcnow)
+    invoice_id = Column(UUID(as_uuid=True), ForeignKey("invoices.id", ondelete="CASCADE"), nullable=False)
+    management_no = Column(String(50), nullable=False)
+    machine_no = Column(String(100), nullable=False)
+    actual_hours = Column(Numeric(10, 2), nullable=False)
+    sort_order = Column(Integer, default=0, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
 
-    # Relationships
+    # リレーション
     invoice = relationship("Invoice", back_populates="items")
-    project = relationship("Project")

--- a/backend/app/schemas/invoice.py
+++ b/backend/app/schemas/invoice.py
@@ -1,0 +1,63 @@
+from pydantic import BaseModel, Field
+from typing import Optional, List
+from datetime import date, datetime
+from uuid import UUID
+from decimal import Decimal
+
+
+class InvoiceItemBase(BaseModel):
+    management_no: str = Field(..., description="管理No")
+    machine_no: str = Field(..., description="機番")
+    actual_hours: Decimal = Field(..., description="実工数")
+    sort_order: int = Field(default=0, description="並び順")
+
+
+class InvoiceItemCreate(InvoiceItemBase):
+    pass
+
+
+class InvoiceItemResponse(InvoiceItemBase):
+    id: UUID
+    invoice_id: UUID
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class InvoiceBase(BaseModel):
+    invoice_number: str = Field(..., description="請求書番号")
+    issue_date: date = Field(..., description="発行日")
+    status: str = Field(default='draft', description="ステータス")
+
+
+class InvoiceCreate(InvoiceBase):
+    items: List[InvoiceItemCreate] = Field(default=[], description="請求書明細")
+
+
+class InvoiceUpdate(BaseModel):
+    status: Optional[str] = None
+
+
+class InvoiceResponse(InvoiceBase):
+    id: UUID
+    total_amount: Decimal
+    created_at: datetime
+    updated_at: datetime
+    items: List[InvoiceItemResponse] = []
+
+    class Config:
+        from_attributes = True
+
+
+# 請求プレビュー用のレスポンス
+class InvoicePreviewItem(BaseModel):
+    management_no: str
+    machine_no: str
+    actual_hours: Decimal
+
+
+class InvoicePreviewResponse(BaseModel):
+    month: str  # YYYY-MM形式
+    total_hours: Decimal
+    items: List[InvoicePreviewItem]

--- a/backend/migrations/20251002_add_management_no_machine_no_to_projects.sql
+++ b/backend/migrations/20251002_add_management_no_machine_no_to_projects.sql
@@ -1,0 +1,13 @@
+-- projectsテーブルに management_no と machine_no を追加
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS management_no VARCHAR(50);
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS machine_no VARCHAR(100);
+
+-- 既存データの更新（nameから抽出）
+UPDATE projects
+SET
+  management_no = SPLIT_PART(name, ' (', 1),
+  machine_no = CASE
+    WHEN POSITION(' (' IN name) > 0 THEN TRIM(TRAILING ')' FROM SPLIT_PART(name, ' (', 2))
+    ELSE ''
+  END
+WHERE management_no IS NULL;

--- a/backend/migrations/20251002_create_invoice_functions.sql
+++ b/backend/migrations/20251002_create_invoice_functions.sql
@@ -1,0 +1,38 @@
+-- 請求書作成のストアドプロシージャ（トランザクション保証）
+CREATE OR REPLACE FUNCTION create_invoice_with_items(
+    p_invoice_number VARCHAR(50),
+    p_issue_date DATE,
+    p_total_amount DECIMAL(12,2),
+    p_status VARCHAR(50),
+    p_items JSONB
+) RETURNS UUID AS $$
+DECLARE
+    v_invoice_id UUID;
+    v_item JSONB;
+BEGIN
+    -- 請求書を作成
+    INSERT INTO invoices (invoice_number, issue_date, total_amount, status)
+    VALUES (p_invoice_number, p_issue_date, p_total_amount, p_status)
+    RETURNING id INTO v_invoice_id;
+
+    -- 明細を一括作成
+    FOR v_item IN SELECT * FROM jsonb_array_elements(p_items)
+    LOOP
+        INSERT INTO invoice_items (
+            invoice_id,
+            management_no,
+            machine_no,
+            actual_hours,
+            sort_order
+        ) VALUES (
+            v_invoice_id,
+            (v_item->>'management_no')::VARCHAR,
+            (v_item->>'machine_no')::VARCHAR,
+            (v_item->>'actual_hours')::DECIMAL,
+            (v_item->>'sort_order')::INTEGER
+        );
+    END LOOP;
+
+    RETURN v_invoice_id;
+END;
+$$ LANGUAGE plpgsql;

--- a/backend/migrations/20251002_create_invoices_tables.sql
+++ b/backend/migrations/20251002_create_invoices_tables.sql
@@ -1,0 +1,27 @@
+-- 請求書テーブルの作成
+CREATE TABLE IF NOT EXISTS invoices (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  invoice_number VARCHAR(50) UNIQUE NOT NULL,
+  issue_date DATE NOT NULL,
+  total_amount DECIMAL(12,2) DEFAULT 0.00 NOT NULL,
+  status VARCHAR(50) DEFAULT 'draft' NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_invoices_number ON invoices(invoice_number);
+CREATE INDEX IF NOT EXISTS idx_invoices_status ON invoices(status);
+
+-- 請求書明細テーブルの作成
+CREATE TABLE IF NOT EXISTS invoice_items (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  invoice_id UUID REFERENCES invoices(id) ON DELETE CASCADE NOT NULL,
+  management_no VARCHAR(50) NOT NULL,
+  machine_no VARCHAR(100) NOT NULL,
+  actual_hours DECIMAL(10,2) NOT NULL,
+  sort_order INTEGER DEFAULT 0 NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_invoice_items_invoice ON invoice_items(invoice_id);
+CREATE INDEX IF NOT EXISTS idx_invoice_items_sort ON invoice_items(sort_order);

--- a/backend/migrations/20251002_rename_work_logs_to_worklogs.sql
+++ b/backend/migrations/20251002_rename_work_logs_to_worklogs.sql
@@ -1,0 +1,9 @@
+-- work_logsテーブルをworklogsにリネーム（Supabaseスキーマキャッシュ問題の回避）
+ALTER TABLE IF EXISTS work_logs RENAME TO worklogs;
+
+-- 外部キー制約も更新
+ALTER TABLE IF EXISTS worklogs RENAME CONSTRAINT work_logs_user_id_fkey TO worklogs_user_id_fkey;
+ALTER TABLE IF EXISTS worklogs RENAME CONSTRAINT work_logs_project_id_fkey TO worklogs_project_id_fkey;
+
+-- インデックスも更新（存在する場合）
+ALTER INDEX IF EXISTS work_logs_pkey RENAME TO worklogs_pkey;

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -122,6 +122,23 @@ export default function DashboardPage() {
             </div>
           </Link>
 
+          {/* 請求書管理カード */}
+          <Link href="/invoices">
+            <div className="bg-white p-6 rounded-lg shadow hover:shadow-lg transition cursor-pointer">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h2 className="text-xl font-semibold text-gray-900 mb-2">請求書管理</h2>
+                  <p className="text-gray-600">月次請求書の作成とCSV出力</p>
+                </div>
+                <div className="text-yellow-600">
+                  <svg className="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </Link>
+
           {/* マスタ管理カード */}
           <Link href="/masters">
             <div className="bg-white p-6 rounded-lg shadow hover:shadow-lg transition cursor-pointer">

--- a/frontend/src/app/invoices/page.tsx
+++ b/frontend/src/app/invoices/page.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { authStorage } from '@/lib/auth';
+
+interface InvoicePreviewItem {
+  management_no: string;
+  machine_no: string;
+  actual_hours: number;
+}
+
+interface InvoicePreview {
+  month: string;
+  total_hours: number;
+  items: InvoicePreviewItem[];
+}
+
+export default function InvoicesPage() {
+  const router = useRouter();
+  const [selectedMonth, setSelectedMonth] = useState('');
+  const [preview, setPreview] = useState<InvoicePreview | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    // 当月をデフォルト値として設定
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    setSelectedMonth(`${year}-${month}`);
+
+    // 管理者権限チェック
+    const user = authStorage.getUser();
+    setIsAdmin(user?.is_admin || false);
+  }, []);
+
+  const loadPreview = async () => {
+    if (!selectedMonth) return;
+
+    const token = authStorage.getToken();
+    if (!token) {
+      router.push('/login');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const response = await fetch(
+        `http://localhost:8000/api/invoices/preview?month=${selectedMonth}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error('請求プレビューの取得に失敗しました');
+      }
+
+      const data = await response.json();
+      setPreview(data);
+    } catch (error) {
+      console.error('請求プレビューの取得に失敗:', error);
+      alert('請求プレビューの取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClose = async () => {
+    if (!isAdmin) {
+      alert('請求書の確定は管理者のみ実行できます');
+      return;
+    }
+
+    if (!confirm('請求書を確定しますか？確定後は編集できません。')) {
+      return;
+    }
+
+    const token = authStorage.getToken();
+    if (!token) return;
+
+    try {
+      const response = await fetch(
+        `http://localhost:8000/api/invoices/close?month=${selectedMonth}`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error('請求書の確定に失敗しました');
+      }
+
+      alert('請求書を確定しました');
+      loadPreview(); // 再読み込み
+    } catch (error) {
+      console.error('請求書の確定に失敗:', error);
+      alert('請求書の確定に失敗しました');
+    }
+  };
+
+  const handleExport = async () => {
+    if (!selectedMonth) return;
+
+    const token = authStorage.getToken();
+    if (!token) return;
+
+    try {
+      const response = await fetch(
+        `http://localhost:8000/api/invoices/export?month=${selectedMonth}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error('CSVエクスポートに失敗しました');
+      }
+
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `invoice_${selectedMonth}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error('CSVエクスポートに失敗:', error);
+      alert('CSVエクスポートに失敗しました');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white shadow">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
+          <h1 className="text-2xl font-bold text-gray-900">請求書管理</h1>
+          <Link
+            href="/dashboard"
+            className="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600"
+          >
+            ダッシュボードへ
+          </Link>
+        </div>
+      </header>
+
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* 月選択 */}
+        <div className="bg-white shadow rounded-lg p-6 mb-6">
+          <h2 className="text-lg font-semibold mb-4">請求月選択</h2>
+          <div className="flex gap-4 items-center">
+            <input
+              type="month"
+              value={selectedMonth}
+              onChange={(e) => setSelectedMonth(e.target.value)}
+              className="border rounded px-3 py-2"
+            />
+            <button
+              onClick={loadPreview}
+              disabled={loading || !selectedMonth}
+              className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 disabled:bg-gray-300"
+            >
+              {loading ? 'Loading...' : 'プレビュー'}
+            </button>
+          </div>
+        </div>
+
+        {/* プレビュー表示 */}
+        {preview && (
+          <>
+            <div className="bg-white shadow rounded-lg p-6 mb-6">
+              <div className="flex justify-between items-center mb-4">
+                <h2 className="text-lg font-semibold">
+                  {preview.month} 請求プレビュー
+                </h2>
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleExport}
+                    className="bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600"
+                  >
+                    CSV出力
+                  </button>
+                  {isAdmin && (
+                    <button
+                      onClick={handleClose}
+                      className="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600"
+                    >
+                      請求確定
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              <div className="mb-4">
+                <p className="text-lg">
+                  合計工数: <span className="font-bold">{preview.total_hours}H</span>
+                </p>
+              </div>
+
+              {preview.items.length === 0 ? (
+                <p className="text-gray-500">請求対象の工数がありません</p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="min-w-full divide-y divide-gray-200">
+                    <thead className="bg-gray-50">
+                      <tr>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                          管理No
+                        </th>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                          委託業務内容
+                        </th>
+                        <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                          実工数
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody className="bg-white divide-y divide-gray-200">
+                      {preview.items.map((item, index) => (
+                        <tr key={index}>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                            {item.management_no}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                            {item.machine_no}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">
+                            {item.actual_hours}H
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要
月次請求書の生成・プレビュー・CSV出力機能を実装しました。

## 実装内容

### データベース
- ✅ `invoices`テーブルと`invoice_items`テーブルを作成
- ✅ `work_logs`を`worklogs`にリネーム（Supabaseスキーマキャッシュ問題回避）
- ✅ `projects`テーブルに`management_no`, `machine_no`カラムを追加

### バックエンドAPI
- ✅ `GET /api/invoices/preview?month=YYYY-MM` - 請求書プレビュー（工数自動集計）
- ✅ `POST /api/invoices/close?month=YYYY-MM` - 請求書確定（管理者のみ）
- ✅ `GET /api/invoices/export?month=YYYY-MM` - CSV出力（BOM付きUTF-8）
- ✅ その他CRUD操作エンドポイント

### フロントエンド
- ✅ 請求書管理画面を実装（`/invoices`）
- ✅ 月次プレビュー機能
- ✅ CSV出力機能
- ✅ ダッシュボードに請求書管理リンクを追加

### 認証
- ✅ `require_admin`関数を追加
- ✅ `is_active`カラムの参照を削除（存在しないため）

## API仕様

### プレビュー
```bash
GET /api/invoices/preview?month=2025-10
Authorization: Bearer {token}

Response:
{
  "month": "2025-10",
  "total_hours": "32.00",
  "items": [
    {
      "management_no": "TEST-001",
      "machine_no": "MACHINE-A",
      "actual_hours": "32.00"
    }
  ]
}
```

### CSV出力
```bash
GET /api/invoices/export?month=2025-10
Authorization: Bearer {token}

Response: CSV file (UTF-8 with BOM)
管理No,委託業務内容,実工数
TEST-001,MACHINE-A,32.00H
```

## テスト結果
- ✅ ログイン機能（新規ユーザー登録で動作確認）
- ✅ 請求書プレビューAPI
- ✅ CSV出力機能
- ⚠️ Supabase Python SDKのキャッシュ問題により、一部データが古いキャッシュから返される場合あり

## 既知の問題
1. **Supabase Python SDKのスキーマキャッシュ問題**
   - `in_()`演算子使用時にスキーマキャッシュが更新されない
   - 回避策: 個別の`eq()`クエリで取得（実装済み）
   - 根本対策: Supabase Python SDKの更新待ち

2. **認証問題（既存）**
   - `qa+shared@example.com`ユーザーでのログイン失敗
   - パスワードハッシュ検証に問題あり（要調査）

## マイグレーション
以下のマイグレーションが適用済みです：
1. `20251002_create_invoices_tables.sql` - 請求書テーブル作成
2. `20251002_rename_work_logs_to_worklogs.sql` - テーブル名変更
3. `20251002_add_management_no_machine_no_to_projects.sql` - プロジェクトカラム追加

## チェックリスト
- [x] データベーステーブル作成
- [x] バックエンドAPI実装
- [x] フロントエンドUI実装
- [x] 認証・認可実装
- [x] マイグレーションファイル作成
- [x] 基本的な動作確認
- [ ] E2Eテスト（Playwright）
- [ ] ドキュメント更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)